### PR TITLE
fix [integration] :: Pinterest custom event option added

### DIFF
--- a/data/destinations/pinterest_tag/ui_config.json
+++ b/data/destinations/pinterest_tag/ui_config.json
@@ -127,6 +127,10 @@
             {
               "name": "AddToCart",
               "value": "AddToCart"
+            },
+            {
+              "name": "Custom",
+              "value": "Custom"
             }
           ]
         }


### PR DESCRIPTION
## Description of the change

> We were defaulting user defined events as custom events. But now we have planned to pass user defined event as it is. Now, adding custom event option in UI mapping

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
