### PR TITLE
fix(qualaroo): remove eventsList from schema

### DIFF
--- a/data/destinations/qualaroo/schema.json
+++ b/data/destinations/qualaroo/schema.json
@@ -15,10 +15,6 @@
       "recordQualarooEvents": {
         "type": "boolean"
       },
-      "eventsList": {
-        "type": "string",
-        "pattern": "^(show|close|submit|noTargetMatch)$"
-      },
       "updateEventNames": {
         "type": "boolean"
       },


### PR DESCRIPTION
## Description of the change

> Removing `eventsList` from schema.
Here eventsList is `singleSelect` with `mode = multiple`. When we select single option eventsList is coming as `string` but when we select more than one option eventsList is coming as an `array`. There is an inconsistency with this component. It should always return an array.

<img width="1728" alt="Screenshot 2022-11-02 at 7 02 04 PM" src="https://user-images.githubusercontent.com/60897972/199507192-9dc450c3-a1a7-489b-824d-00fc079865b0.png">
<img width="1728" alt="Screenshot 2022-11-02 at 7 02 32 PM" src="https://user-images.githubusercontent.com/60897972/199507239-2defa001-c2d2-4371-b98a-ab049e536f69.png">



## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
