### PR TITLE
chore: enable singer facebook marketing source

### DIFF
--- a/data/sources/singer_facebook_marketing/db_config.json
+++ b/data/sources/singer_facebook_marketing/db_config.json
@@ -4,7 +4,7 @@
   "displayName": "Facebook Marketing",
   "options": {
     "isBeta": true,
-    "image": "rudderstack/source-facebook-marketing:v4.0.0",
+    "image": "rudderstack/source-facebook-marketing:v4.0.1",
     "hidden": false
   }
 }


### PR DESCRIPTION
## Description of the change
we want to enable the FB marketing source for the verification process of the new oauth app .

> Description here

[ticket](https://www.notion.so/rudderstacks/Facebook-marketing-app-verification-25b9301ebb3d4460bac5618c2ec71ec5)


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
