### PR TITLE
chore: sync retl dev environment

### DIFF
--- a/.github/workflows/dev-deploy.yaml
+++ b/.github/workflows/dev-deploy.yaml
@@ -44,3 +44,4 @@ jobs:
         run: |
          python scripts/action.py https://api.dev.rudderlabs.com
          python scripts/action.py https://api.staging.rudderlabs.com
+         python scripts/action.py https://sources-api.dev.rudderlabs.com


### PR DESCRIPTION
## Purpose

Sync development branch with sources-demo (rETL's testing environment) deployment.


## Approach
Fortunately enough these dev environments share the same db creds.