### PR TITLE
fix(s3-source): making default option accessKey for backward compatibility

### DIFF
--- a/data/sources/s3/ui_config.json
+++ b/data/sources/s3/ui_config.json
@@ -26,7 +26,7 @@
             }
           ],
           "defaultOption": {
-            "value": "crossAccountRole"
+            "value": "accessKey"
           }
         },
         {


### PR DESCRIPTION

## Description of the change

To support view of credentials of old account without the choice of cross account we need to set default to `accessKey`

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
