### PR TITLE
chore(warehouse): make access keys as optional for AWS object storage since we now have IAM roles

### DIFF
--- a/data/destinations/azure_synapse/schema.json
+++ b/data/destinations/azure_synapse/schema.json
@@ -120,11 +120,11 @@
             },
             "accessKeyID": {
               "type": "string",
-              "pattern": "(^env[.].+)|^(.{1,100})$"
+              "pattern": "(^env[.].+)|^(.{0,100})$"
             },
             "accessKey": {
               "type": "string",
-              "pattern": "(^env[.].+)|^(.{1,100})$"
+              "pattern": "(^env[.].+)|^(.{0,100})$"
             }
           },
           "required": [

--- a/data/destinations/clickhouse/schema.json
+++ b/data/destinations/clickhouse/schema.json
@@ -143,11 +143,11 @@
             },
             "accessKeyID": {
               "type": "string",
-              "pattern": "(^env[.].+)|^(.{1,100})$"
+              "pattern": "(^env[.].+)|^(.{0,100})$"
             },
             "accessKey": {
               "type": "string",
-              "pattern": "(^env[.].+)|^(.{1,100})$"
+              "pattern": "(^env[.].+)|^(.{0,100})$"
             }
           },
           "required": [

--- a/data/destinations/deltalake/schema.json
+++ b/data/destinations/deltalake/schema.json
@@ -143,11 +143,11 @@
                 },
                 "accessKeyID": {
                   "type": "string",
-                  "pattern": "(^env[.].*)|^(.{1,100})$"
+                  "pattern": "(^env[.].*)|^(.{0,100})$"
                 },
                 "accessKey": {
                   "type": "string",
-                  "pattern": "(^env[.].*)|^(.{1,100})$"
+                  "pattern": "(^env[.].*)|^(.{0,100})$"
                 }
               },
               "required": [

--- a/data/destinations/mssql/schema.json
+++ b/data/destinations/mssql/schema.json
@@ -120,11 +120,11 @@
             },
             "accessKeyID": {
               "type": "string",
-              "pattern": "(^env[.].+)|^(.{1,100})$"
+              "pattern": "(^env[.].+)|^(.{0,100})$"
             },
             "accessKey": {
               "type": "string",
-              "pattern": "(^env[.].+)|^(.{1,100})$"
+              "pattern": "(^env[.].+)|^(.{0,100})$"
             }
           },
           "required": [

--- a/data/destinations/postgres/schema.json
+++ b/data/destinations/postgres/schema.json
@@ -124,11 +124,11 @@
             },
             "accessKeyID": {
               "type": "string",
-              "pattern": "(^env[.].+)|^(.{1,100})$"
+              "pattern": "(^env[.].+)|^(.{0,100})$"
             },
             "accessKey": {
               "type": "string",
-              "pattern": "(^env[.].+)|^(.{1,100})$"
+              "pattern": "(^env[.].+)|^(.{0,100})$"
             }
           },
           "required": [

--- a/data/destinations/snowflake/schema.json
+++ b/data/destinations/snowflake/schema.json
@@ -139,11 +139,11 @@
             },
             "accessKeyID": {
               "type": "string",
-              "pattern": "(^env[.].+)|^(.{1,100})$"
+              "pattern": "(^env[.].+)|^(.{0,100})$"
             },
             "accessKey": {
               "type": "string",
-              "pattern": "(^env[.].+)|^(.{1,100})$"
+              "pattern": "(^env[.].+)|^(.{0,100})$"
             },
             "enableSSE": {
               "type": "boolean"


### PR DESCRIPTION
## Description of the change

- Since we now have `iamRoleARN` for Object storage destinations with with S3 configured. So we are making `accessKeyID` and `accessKey` as optional.
- https://www.notion.so/rudderstacks/Warehouse-destination-config-for-Role-base-Authentication-control-plane-db9198dce2024723959c224e91a11ef4

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
