### PR TITLE
feat: removed preRequisiteField for supportDedup property in Braze ui_config

### DIFF
--- a/data/destinations/braze/ui_config.json
+++ b/data/destinations/braze/ui_config.json
@@ -74,10 +74,6 @@
           "default": true
         },
         {
-          "preRequisiteField": {
-            "name": "useNativeSDK",
-            "selectedValue": true
-          },
           "type": "checkbox",
           "label": "Deduplicate Traits",
           "value": "supportDedup",


### PR DESCRIPTION
## Description of the change

> Removed `preRequisiteField` parameter for `supportDedup` property in Braze's ui_config

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
