### PR TITLE
chore: add intg pod owners to specific directories in codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 * @ItsSudip @shrouti1507 @sandeepdsvs @krishna2020
-/src/configurations/ @nidhilashkari17 @debanjan97 @ssbeefeater @AchuthaSourabhC @ruchiramoitra @ashishRudder
-/test/ @nidhilashkari17 @debanjan97 @ssbeefeater @AchuthaSourabhC @ruchiramoitra @ashishRudder
+/src/configurations/ @nidhilashkari17 @debanjan97 @ssbeefeater @AchuthaSourabhC @ruchiramoitra @ashishRudder @ItsSudip @shrouti1507 @sandeepdsvs @krishna2020
+/test/ @nidhilashkari17 @debanjan97 @ssbeefeater @AchuthaSourabhC @ruchiramoitra @ashishRudder @ItsSudip @shrouti1507 @sandeepdsvs @krishna2020


### PR DESCRIPTION
## Description of the change

According to GitHub convention([ref](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file)) the last matching file pattern will take the precedence over previous patterns. So to make integration `pod-owners` owners of `/src/configurations/` and `/test/`, pod-owners names should also be added in this pattern apart from `*` pattern

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
