### PR TITLE
fix: enable cdkv2 for algolia and pinterest

### DIFF
--- a/src/configurations/destinations/algolia/db-config.json
+++ b/src/configurations/destinations/algolia/db-config.json
@@ -2,7 +2,7 @@
   "name": "ALGOLIA",
   "displayName": "Algolia",
   "config": {
-    "cdkV2TestThreshold": 1,
+    "cdkV2Enabled": true,
     "transformAt": "router",
     "transformAtV1": "router",
     "saveDestinationResponse": true,

--- a/src/configurations/destinations/pinterest_tag/db-config.json
+++ b/src/configurations/destinations/pinterest_tag/db-config.json
@@ -2,7 +2,7 @@
   "name": "PINTEREST_TAG",
   "displayName": "Pinterest Tag",
   "config": {
-    "cdkV2TestThreshold": 1,
+    "cdkV2Enabled": true,
     "transformAt": "router",
     "transformAtV1": "router",
     "saveDestinationResponse": false,


### PR DESCRIPTION

## Description of the change

This is to use workflow engine for destination transformations.

Using fix as this is hotfix release.

Note: This is effective only in hosted prod as we are controlling this with an Environment variable also so when both are enabled then only destinations traffic will be sent to cdkv2.

## Checklists

### Development

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
