### PR TITLE
chore: remove connecting warehouse destinations from rETL

### DIFF
--- a/src/configurations/destinations/azure_datalake/db-config.json
+++ b/src/configurations/destinations/azure_datalake/db-config.json
@@ -15,7 +15,6 @@
       "unity",
       "amp",
       "cloud",
-      "warehouse",
       "reactnative",
       "cloudSource",
       "flutter",
@@ -34,6 +33,9 @@
         "syncStartAt"
       ]
     },
-    "secretKeys": ["accountKey", "sasToken"]
+    "secretKeys": [
+      "accountKey",
+      "sasToken"
+    ]
   }
 }

--- a/src/configurations/destinations/deltalake/db-config.json
+++ b/src/configurations/destinations/deltalake/db-config.json
@@ -15,7 +15,6 @@
       "unity",
       "amp",
       "cloud",
-      "warehouse",
       "reactnative",
       "cloudSource",
       "flutter",

--- a/src/configurations/destinations/gcs_datalake/db-config.json
+++ b/src/configurations/destinations/gcs_datalake/db-config.json
@@ -15,7 +15,6 @@
       "unity",
       "amp",
       "cloud",
-      "warehouse",
       "reactnative",
       "cloudSource",
       "flutter",

--- a/src/configurations/destinations/s3_datalake/db-config.json
+++ b/src/configurations/destinations/s3_datalake/db-config.json
@@ -18,7 +18,6 @@
       "reactnative",
       "cloudSource",
       "flutter",
-      "warehouse",
       "cordova"
     ],
     "destConfig": {
@@ -37,6 +36,10 @@
         "excludeWindow"
       ]
     },
-    "secretKeys": ["password", "accessKeyID", "accessKey"]
+    "secretKeys": [
+      "password",
+      "accessKeyID",
+      "accessKey"
+    ]
   }
 }


### PR DESCRIPTION
## Description of the change

Remove connection of rETL to warehouse destinations.

## Notion task

[Task link](https://www.notion.so/rudderstacks/cfe8e8ef60a34485a373e789b7b6933a?v=a07a0b1350f84d46af9792260b39a194&p=0ef713e20e2c47439480b8b2c3db2b7e&pm=c)

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
