### PR TITLE
fix: default blockPageViewEvent enabled to prevent duplicate page calls

### DIFF
--- a/src/configurations/destinations/ga4/ui-config.json
+++ b/src/configurations/destinations/ga4/ui-config.json
@@ -182,7 +182,7 @@
           "type": "checkbox",
           "label": "Block a Page View Event",
           "value": "blockPageViewEvent",
-          "default": false
+          "default": true
         },
         {
           "type": "checkbox",


### PR DESCRIPTION
## Description of the change
<img width="439" alt="image" src="https://user-images.githubusercontent.com/77438541/215385048-703f1ea9-8f98-415e-a44b-8aa8666eca88.png">


## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
