### PR TITLE
Feat/generate configs from schema.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.2",
+        "eta": "^2.0.0",
         "glob": "^8.0.3"
       },
       "devDependencies": {
@@ -8072,6 +8073,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eta": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.0.tgz",
+      "integrity": "sha512-NqE7S2VmVwgMS8yBxsH4VgNQjNjLq1gfGU0u9I6Cjh468nPRMoDfGdK9n1p/3Dvsw3ebklDkZsFAnKJ9sefjBA==",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/eta-dev/eta?sponsor=1"
       }
     },
     "node_modules/events": {
@@ -20336,6 +20348,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "eta": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.0.tgz",
+      "integrity": "sha512-NqE7S2VmVwgMS8yBxsH4VgNQjNjLq1gfGU0u9I6Cjh468nPRMoDfGdK9n1p/3Dvsw3ebklDkZsFAnKJ9sefjBA=="
     },
     "events": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "ajv": "^8.11.2",
+    "eta": "^2.0.0",
     "glob": "^8.0.3"
   },
   "lint-staged": {

--- a/src/configurations/destinations/am/field.py
+++ b/src/configurations/destinations/am/field.py
@@ -1,0 +1,132 @@
+# moving repeated fields from uiConfig.json to schema.json 
+# uiConfig = baseTemplate arr + sdkTemplate obj 
+# sdkTemplate.fields has arr
+# baseTemplate has objects with a title
+# Each baseTemplate object  -> sections arr -> groupsArr  -> fields arr
+# and fields array has regex, regexErrorMessage, placeHolder, secret
+# field types: 
+#   textInput
+#   tagInput
+#   checkbox
+#   singleSelect
+
+# Class to represent repeated keys
+class Field:
+    def __init__(self, type , label, configKey, regex, regexErrorMessage, placeholder, secret):
+        # data members (instance variables)
+        self.type = type
+        self.label = label
+        self.configKey = configKey
+        self.regex = regex
+        self.regexErrorMessage = regexErrorMessage
+        self.placeholder = placeholder
+        self.secret = secret
+    def __str__(self):
+        return "type: " + self.type + ", label: " + self.label + ", configKey: " + self.configKey + " regex: " + self.regex + ", regexErrorMessage: " + self.regexErrorMessage + ", placeholder: " + self.placeholder + ", secret: " + str(self.secret)
+def registerField(field, configKeyMap):
+    if field['type'] == "textInput": 
+        #print(json.dumps(field, indent=2))
+        typeF,  labelF, configKeyF, regexF, regexErrorMessageF, placeholderF, secretF = "", "", "", "", "", "", False
+        try: 
+            typeF = field['type']
+        except KeyError:
+            pass
+        try: 
+            labelF = field['label']
+        except KeyError: 
+            pass
+        try: 
+            configKeyF = field['configKey']
+        except KeyError: 
+            pass
+        try: 
+            regexF = field['regex']
+        except KeyError:
+            pass
+        try: 
+            regexErrorMessageF = field['regexErrorMessage']
+            # print("debug: ", regexErrorMessageF)
+        except KeyError: 
+            pass
+        try: 
+            placeholderF = field['placeholder']
+        except KeyError: 
+            pass
+        try: 
+            secretF = field['secret']
+            if secretF == "": 
+                secretF = False
+        except KeyError:
+            pass
+        configKeyMap[configKeyF] = Field(typeF, labelF, configKeyF, regexF, regexErrorMessageF, placeholderF, secretF)
+    elif field['type'] == "tagInput":
+        #print(json.dumps(field, indent=2))
+        labelF, configKeyF, placeholderF = "", "", ""
+        try: 
+            labelF = field['label']
+        except KeyError:
+            pass
+        try:
+            configKeyF = field['configKey'] 
+        except KeyError:
+            pass
+        try: 
+            placeholderF = field['placeholder']
+        except KeyError:
+            pass
+        configKeyMap[configKeyF] = Field(field['type'], labelF, configKeyF, "", "", placeholderF, False)
+        #print(configKeyMap[configKeyF].type)
+    elif field['type'] == "checkbox":
+        #print(json.dumps(field, indent=2))
+        labelF, configKeyF, placeholderF = "", "", ""
+        try: 
+            labelF = field['label']
+        except KeyError:
+            pass
+        try:
+            configKeyF = field['configKey'] 
+        except KeyError:
+            pass
+        try: 
+            placeholderF = field['placeholder']
+        except KeyError:
+            pass
+        configKeyMap[configKeyF] = Field(field['type'], labelF, configKeyF, "", "", placeholderF, False)
+        #print(configKeyMap[configKeyF].type)
+    elif field['type'] == "singleSelect":
+        #print(json.dumps(field, indent=2))
+        labelF, configKeyF, placeholderF = "", "", ""
+        try: 
+            labelF = field['label']
+        except KeyError:
+            pass
+        try:
+            configKeyF = field['configKey'] 
+        except KeyError:
+            pass
+        try: 
+            placeholderF = field['placeholder']
+        except KeyError:
+            pass
+        configKeyMap[configKeyF] = Field(field['type'], labelF, configKeyF, "", "", placeholderF, False)
+        #print(configKeyMap[configKeyF].type)
+    elif field['type'] == "connectionMode":
+       #print(json.dumps(field, indent=2))
+        labelF, configKeyF, placeholderF = "", "", ""
+        try: 
+            labelF = field['label']
+        except KeyError:
+            pass
+        try:
+            configKeyF = field['configKey'] 
+        except KeyError:
+            pass
+        try: 
+            placeholderF = field['placeholder']
+        except KeyError:
+            pass
+        configKeyMap[configKeyF] = Field(field['type'], labelF, configKeyF, "", "", placeholderF, False)
+        #print(configKeyMap[configKeyF].type)
+    else: 
+        print("typeF", field['type'])
+        print("field type not found")

--- a/src/configurations/destinations/am/moveToSchema.py
+++ b/src/configurations/destinations/am/moveToSchema.py
@@ -1,0 +1,55 @@
+import json
+
+# from jinja2 import Environment, PackageLoader, select_autoescape
+# env = Environment(
+#     loader=PackageLoader("templates"),
+#     autoescape=select_autoescape()
+# )
+
+with open('ui-config.json', 'r') as uiconfig: 
+    uiconfig = json.load(uiconfig)
+
+from field import registerField
+
+configKeyMap = dict()
+baseTemplate = uiconfig['uiConfig']['baseTemplate']
+for baseTempObj in baseTemplate: 
+    for section in baseTempObj['sections']:
+        for group in section['groups']:
+            for field in group['fields']:
+                registerField(field, configKeyMap)
+
+sdkFields = uiconfig['uiConfig']['sdkTemplate']['fields']
+for field in sdkFields:
+   registerField(field, configKeyMap)
+
+#===============================================================================#
+
+with open('schema.json', 'r') as schema:
+    schema = json.load(schema)
+
+schemaProps = schema['configSchema']['properties']
+for property in schemaProps: 
+    if property in configKeyMap:
+        if schemaProps[property]['type'] != "array": 
+            # print(configKeyMap[property])
+            schemaProps[property]['regex'] = configKeyMap[property].regex
+            schemaProps[property]['label'] = configKeyMap[property].label
+            schemaProps[property]['regexErrorMessage'] = configKeyMap[property].regexErrorMessage
+            schemaProps[property]['placeholder'] = configKeyMap[property].placeholder
+            schemaProps[property]['secret'] = configKeyMap[property].secret
+        else: 
+            try: 
+                schemaProps[property]['items']['properties']['traits']['label'] = configKeyMap[property].label
+            except KeyError:    
+                schemaProps[property]['items']['properties']['eventName']['label'] = configKeyMap[property].label
+            try:
+                schemaProps[property]['items']['properties']['traits']['placeholder'] = configKeyMap[property].placeholder
+            except KeyError: 
+                schemaProps[property]['items']['properties']['eventName']['placeholder'] = configKeyMap[property].placeholder
+
+
+schema['configSchema']['properties'] = schemaProps
+with open('schema_modified.json', 'w') as schema_modified:
+    schema = json.dump(schema, schema_modified, indent=2)
+print(json.dumps(schema, indent=2))

--- a/src/configurations/destinations/am/schema_modified.json
+++ b/src/configurations/destinations/am/schema_modified.json
@@ -1,0 +1,477 @@
+{
+  "configSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+      "apiKey"
+    ],
+    "properties": {
+      "apiKey": {
+        "type": "string",
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$",
+        "regex": "^(.{1,100})$",
+        "label": "API Key",
+        "regexErrorMessage": "Invalid Api Key",
+        "placeholder": "e.g: bSjsdGYsOo9sjw23Shj",
+        "secret": true
+      },
+      "apiSecret": {
+        "type": "string",
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+        "regex": "^(.{0,100})$",
+        "label": "Secret key",
+        "regexErrorMessage": "Invalid Api Key",
+        "placeholder": "e.g: bSjsdGYsOo9sjw23Shj",
+        "secret": true
+      },
+      "groupTypeTrait": {
+        "type": "string",
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+        "regex": "^(.{0,100})$",
+        "label": "Group name trait",
+        "regexErrorMessage": "Invalid Group Name Trait",
+        "placeholder": "e.g: company_id",
+        "secret": false
+      },
+      "groupValueTrait": {
+        "type": "string",
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+        "regex": "^(.{0,100})$",
+        "label": "Group value trait",
+        "regexErrorMessage": "Invalid Group Name Trait",
+        "placeholder": "e.g: company_name",
+        "secret": false
+      },
+      "trackAllPages": {
+        "type": "boolean",
+        "regex": "",
+        "label": "Track all Pages to Amplitude",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "trackCategorizedPages": {
+        "type": "boolean",
+        "regex": "",
+        "label": "Track Categorized Pages to Amplitude",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "trackNamedPages": {
+        "type": "boolean",
+        "regex": "",
+        "label": "Track Named Pages to Amplitude",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "trackProductsOnce": {
+        "type": "boolean",
+        "regex": "",
+        "label": "Track products as a single event",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "trackRevenuePerProduct": {
+        "type": "boolean",
+        "regex": "",
+        "label": "Track Revenue per product",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "versionName": {
+        "type": "string",
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+        "regex": "^(.{0,100})$",
+        "label": "Version Name",
+        "regexErrorMessage": "Invalid Version Name",
+        "placeholder": "e.g: 1.12.3",
+        "secret": false
+      },
+      "residencyServer": {
+        "type": "string",
+        "pattern": "(^env[.].*)|^(standard|EU)$",
+        "regex": "",
+        "label": "Residency server",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "traitsToIncrement": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "traits": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+              "label": "Traits to increment",
+              "placeholder": "e.g: Revenue"
+            }
+          }
+        }
+      },
+      "traitsToSetOnce": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "traits": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+              "label": "Traits to set once",
+              "placeholder": "e.g: lastName"
+            }
+          }
+        }
+      },
+      "traitsToAppend": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "traits": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+              "label": "Traits to append",
+              "placeholder": "e.g: createdAt"
+            }
+          }
+        }
+      },
+      "traitsToPrepend": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "traits": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+              "label": "Traits to prepend",
+              "placeholder": "e.g: createdAt"
+            }
+          }
+        }
+      },
+      "useNativeSDK": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          },
+          "ios": {
+            "type": "boolean"
+          },
+          "android": {
+            "type": "boolean"
+          },
+          "reactnative": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "preferAnonymousIdForDeviceId": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Replace Device ID with Anonymous ID",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "deviceIdFromUrlParam": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Set Device ID From URL Parameter",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "forceHttps": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Force HTTPS",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "trackGclid": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Track GCLID",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "trackReferrer": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Track referrer information",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "saveParamsReferrerOncePerSession": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Save Referrer, URL Params, GCLID only once per session",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "trackUtmProperties": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Track UTM properties",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "unsetParamsReferrerOnNewSession": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Reset referrer or UTM params for new sessions",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "batchEvents": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Batch events prior to upload",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "whitelistedEvents": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "eventName": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+              "label": "Allowlisted events",
+              "placeholder": "e.g: Anonymous page visit"
+            }
+          }
+        }
+      },
+      "blacklistedEvents": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "eventName": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+              "label": "Denylisted events",
+              "placeholder": "e.g: Anonymous page visit"
+            }
+          }
+        }
+      },
+      "eventUploadPeriodMillis": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "string",
+            "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+          },
+          "android": {
+            "type": "string",
+            "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+          },
+          "ios": {
+            "type": "string",
+            "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+          },
+          "reactnative": {
+            "type": "string",
+            "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+          }
+        },
+        "regex": "^([0-9]{0,100})$",
+        "label": "Batch event upload period (ms)",
+        "regexErrorMessage": "Invalid Value",
+        "placeholder": "e.g: 30000",
+        "secret": false
+      },
+      "eventUploadThreshold": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "string",
+            "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+          },
+          "android": {
+            "type": "string",
+            "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+          },
+          "ios": {
+            "type": "string",
+            "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+          },
+          "reactnative": {
+            "type": "string",
+            "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+          }
+        },
+        "regex": "^([0-9]{0,100})$",
+        "label": "Batch event upload threshold",
+        "regexErrorMessage": "Invalid Value",
+        "placeholder": "e.g: 30",
+        "secret": false
+      },
+      "mapDeviceBrand": {
+        "type": "boolean",
+        "regex": "",
+        "label": "Map device brand",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "enableLocationListening": {
+        "type": "object",
+        "properties": {
+          "android": {
+            "type": "boolean"
+          },
+          "reactnative": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Enable location listening",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "trackSessionEvents": {
+        "type": "object",
+        "properties": {
+          "android": {
+            "type": "boolean"
+          },
+          "ios": {
+            "type": "boolean"
+          },
+          "reactnative": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Track session events",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "useAdvertisingIdForDeviceId": {
+        "type": "object",
+        "properties": {
+          "android": {
+            "type": "boolean"
+          },
+          "reactnative": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Use Advertising ID for Device ID",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "useIdfaAsDeviceId": {
+        "type": "object",
+        "properties": {
+          "ios": {
+            "type": "boolean"
+          },
+          "reactnative": {
+            "type": "boolean"
+          }
+        },
+        "regex": "",
+        "label": "Use IDFA for Device ID",
+        "regexErrorMessage": "",
+        "placeholder": "",
+        "secret": false
+      },
+      "oneTrustCookieCategories": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              }
+            }
+          }
+        },
+        "regex": "",
+        "label": "Cookie category name",
+        "regexErrorMessage": "",
+        "placeholder": "e.g: Credit card visit",
+        "secret": false
+      }
+    }
+  }
+}

--- a/src/configurations/destinations/am/templates/schema_tmp.json
+++ b/src/configurations/destinations/am/templates/schema_tmp.json
@@ -1,0 +1,379 @@
+{
+    "configSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": ["apiKey"],
+      "properties": {
+        "apiKey": {
+          "type": "string",
+          "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"
+        },
+        "apiSecret": {
+          "type": "string",
+          "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+          "regex": "^(.{0,100})$",
+          "regexErrorMessage": "Invalid Api Key",
+          "placeholder": "e.g: bSjsdGYsOo9sjw23Shj",
+          "label": "Secret key",
+          "secret": true
+        },
+        "groupTypeTrait": {
+          "type": "string",
+          "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+          "label": "Group name trait",
+          "regex": "^(.{0,100})$",
+          "placeholder": "e.g: company_id",
+          "regexErrorMessage": "Invalid Group Name Trait"
+        },
+        "groupValueTrait": {
+          "type": "string",
+          "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+          "label": "Group value trait",
+          "placeholder": "e.g: company_name",
+          "regex": "^(.{0,100})$",
+          "regexErrorMessage": "Invalid Group Name Trait"
+        },
+        "trackAllPages": {
+          "type": "boolean",
+          "label": "Track all Pages to Amplitude"
+        },
+        "trackCategorizedPages": {
+          "type": "boolean",
+          "label": "Track Categorized Pages to Amplitude"
+        },
+        "trackNamedPages": {
+          "type": "boolean",
+          "label": "Track Named Pages to Amplitude"
+        },
+        "trackProductsOnce": {
+          "type": "boolean",
+          "label": "Track products as a single event"
+        },
+        "trackRevenuePerProduct": {
+          "type": "boolean",
+          "label": "Track Revenue per product"
+        },
+        "versionName": {
+          "type": "string",
+          "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+          "label": "Version Name",
+          "regex": "^(.{0,100})$",
+          "regexErrorMessage": "Invalid Version Name",
+          "placeholder": "e.g: 1.12.3",
+          "secret": false
+        },
+        "residencyServer": {
+          "type": "string",
+          "pattern": "(^env[.].*)|^(standard|EU)$",
+          "label": "Residency server"
+        },
+        "traitsToIncrement": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "traits": {
+                "type": "string",
+                "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+                "label": "Traits to increment",
+                "placeholder": "e.g: Revenue"
+              }
+            }
+          }
+        },
+        "traitsToSetOnce": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "traits": {
+                "type": "string",
+                "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+                "label": "Traits to set once",
+                "placeholder": "e.g: lastName"
+              }
+            }
+          }
+        },
+        "traitsToAppend": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "traits": {
+                "type": "string",
+                "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+                "label": "Traits to append",
+                "placeholder": "e.g: createdAt"
+              }
+            }
+          }
+        },
+        "traitsToPrepend": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "traits": {
+                "type": "string",
+                "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+                "label": "Traits to prepend",
+                "placeholder": "e.g: createdAt"
+              }
+            }
+          }
+        },
+        "useNativeSDK": {
+          "type": "object",
+          "label": "",
+          "properties": {
+            "web": {
+              "type": "boolean"
+            },
+            "ios": {
+              "type": "boolean"
+            },
+            "android": {
+              "type": "boolean"
+            },
+            "reactnative": {
+              "type": "boolean"
+            }
+          }
+        },
+        "preferAnonymousIdForDeviceId": {
+          "type": "object",
+          "label": "Replace Device ID with Anonymous ID",
+          "properties": {
+            "web": {
+              "type": "boolean"
+            }
+          }
+        },
+        "deviceIdFromUrlParam": {
+          "type": "object",
+          "label": "Set Device ID From URL Parameter",
+          "properties": {
+            "web": {
+              "type": "boolean"
+            }
+          }
+        },
+        "forceHttps": {
+          "type": "object",
+          "label": "Force HTTPS",
+          "properties": {
+            "web": {
+              "type": "boolean"
+            }
+          }
+        },
+        "trackGclid": {
+          "type": "object",
+          "label": "Track GCLID",
+          "properties": {
+            "web": {
+              "type": "boolean"
+            }
+          }
+        },
+        "trackReferrer": {
+          "type": "object",
+          "label": "Track referrer information",
+          "properties": {
+            "web": {
+              "type": "boolean"
+            }
+          }
+        },
+        "saveParamsReferrerOncePerSession": {
+          "type": "object",
+          "label": "Save Referrer, URL Params, GCLID only once per session",
+          "properties": {
+            "web": {
+              "type": "boolean"
+            }
+          }
+        },
+        "trackUtmProperties": {
+          "type": "object",
+          "label": "Track UTM properties",
+          "properties": {
+            "web": {
+              "type": "boolean"
+            }
+          }
+        },
+        "unsetParamsReferrerOnNewSession": {
+          "type": "object",
+          "label": "Reset referrer or UTM params for new sessions",
+          "properties": {
+            "web": {
+              "type": "boolean"
+            }
+          }
+        },
+        "batchEvents": {
+          "type": "object",
+          "label": "Batch events prior to upload",
+          "properties": {
+            "web": {
+              "type": "boolean"
+            }
+          }
+        },
+        "whitelistedEvents": {
+          "type": "array",
+          "label": "Allowlisted events",
+          "placeholder": "e.g: Anonymous page visit",
+          "items": {
+            "type": "object",
+            "properties": {
+              "eventName": {
+                "type": "string",
+                "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+              }
+            }
+          }
+        },
+        "blacklistedEvents": {
+          "type": "array",
+          "label": "Denylisted events", 
+          "placeholder": "e.g: Anonymous page visit",
+          "items": {
+            "type": "object",
+            "properties": {
+              "eventName": {
+                "type": "string",
+                "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+              }
+            }
+          }
+        },
+        "eventUploadPeriodMillis": {
+          "type": "object",
+          "label": "Batch event upload period (ms)",
+          "regex": "^([0-9]{0,100})$",
+          "regexErrorMessage": "Invalid Value",
+          "placeholder": "e.g: 30000",
+          "properties": {
+            "web": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+            },
+            "android": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+            },
+            "ios": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+            },
+            "reactnative": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+            }
+          }
+        },
+        "eventUploadThreshold": {
+          "type": "object",
+          "label": "Batch event upload threshold",
+          "regex": "^([0-9]{0,100})$",
+          "regexErrorMessage": "Invalid Value",
+          "placeholder": "e.g: 30",
+          "properties": {
+            "web": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+            },
+            "android": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+            },
+            "ios": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+            },
+            "reactnative": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^([0-9]{0,100})$"
+            }
+          }
+        },
+        "mapDeviceBrand": {
+          "type": "boolean",
+          "label": "Map device brand"
+        },
+        "enableLocationListening": {
+          "type": "object",
+          "label": "Enable location listening",
+          "properties": {
+            "android": {
+              "type": "boolean"
+            },
+            "reactnative": {
+              "type": "boolean"
+            }
+          }
+        },
+        "trackSessionEvents": {
+          "type": "object",
+          "label": "Track session events",
+          "properties": {
+            "android": {
+              "type": "boolean"
+            },
+            "ios": {
+              "type": "boolean"
+            },
+            "reactnative": {
+              "type": "boolean"
+            }
+          }
+        },
+        "useAdvertisingIdForDeviceId": {
+          "type": "object",
+          "label": "Use Advertising ID for Device ID",
+          "properties": {
+            "android": {
+              "type": "boolean"
+            },
+            "reactnative": {
+              "type": "boolean"
+            }
+          }
+        },
+        "useIdfaAsDeviceId": {
+          "type": "object",
+          "label": "Use IDFA for Device ID",
+          "properties": {
+            "ios": {
+              "type": "boolean"
+            },
+            "reactnative": {
+              "type": "boolean"
+            }
+          }
+        },
+        "oneTrustCookieCategories": {
+          "type": "object",
+          "label": "Cookie category name",
+          "placeholder": "e.g: Credit card visit",
+          "properties": {
+            "web": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "oneTrustCookieCategory": {
+                    "type": "string",
+                    "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "resolveJsonModule": true,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */


### PR DESCRIPTION
## Description of the change

This PR is to write migration code to avoid duplication of keys in configs. There will be two migration scripts one to move duplicated values from ui-config.json to schema.json and second script will use the new schema.json to generate rest of the configs. 

## Checklists

### Development

- [] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [] The code changed/added as part of this pull request has been covered with tests
- [] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
