### PR TITLE
chore: update VDM for destinations

### DIFF
--- a/src/configurations/destinations/intercom/db-config.json
+++ b/src/configurations/destinations/intercom/db-config.json
@@ -2,6 +2,7 @@
   "name": "INTERCOM",
   "displayName": "Intercom",
   "config": {
+    "supportsVisualMapper": true,
     "transformAt": "processor",
     "transformAtV1": "processor",
     "saveDestinationResponse": true,

--- a/src/configurations/destinations/klaviyo/db-config.json
+++ b/src/configurations/destinations/klaviyo/db-config.json
@@ -2,6 +2,7 @@
   "name": "KLAVIYO",
   "displayName": "Klaviyo",
   "config": {
+    "supportsVisualMapper": true,
     "transformAt": "router",
     "transformAtV1": "router",
     "saveDestinationResponse": true,

--- a/src/configurations/destinations/shynet/db-config.json
+++ b/src/configurations/destinations/shynet/db-config.json
@@ -2,7 +2,6 @@
   "name": "SHYNET",
   "displayName": "Shynet",
   "config": {
-    "supportsVisualMapper": true,
     "transformAt": "processor",
     "transformAtV1": "processor",
     "saveDestinationResponse": true,


### PR DESCRIPTION
## Description of the change

Remove VDM for shynet and enable for intercom and klaviyo

Notion Ticket: https://www.notion.so/rudderstacks/cfe8e8ef60a34485a373e789b7b6933a?v=a07a0b1350f84d46af9792260b39a194&p=963841a6c3ee445abea2cbec415e68d7&pm=c

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
