### PR TITLE
chore: disable creating connections from rETL to criteo audience

### DIFF
--- a/src/configurations/destinations/criteo_audience/db-config.json
+++ b/src/configurations/destinations/criteo_audience/db-config.json
@@ -10,7 +10,7 @@
     "saveDestinationResponse": true,
     "includeKeys": [],
     "excludeKeys": [],
-    "supportedSourceTypes": ["cloud", "warehouse"],
+    "supportedSourceTypes": ["cloud"],
     "syncBehaviours": [],
     "supportedMessageTypes": ["audiencelist"],
     "destConfig": {


### PR DESCRIPTION
## Description of the change

Disable creating connections from rETL to criteo audience.

## Notion

[Ticket link](https://www.notion.so/rudderstacks/cfe8e8ef60a34485a373e789b7b6933a?v=a07a0b1350f84d46af9792260b39a194&p=f56cf1eaf3194a0cbb680165c8839c93&pm=c)


## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
