### PR TITLE
fix: reverting an unwanted change, adding connectionMode field back to uiConfig

### DIFF
--- a/src/configurations/destinations/am/ui-config.json
+++ b/src/configurations/destinations/am/ui-config.json
@@ -576,6 +576,14 @@
           "regexErrorMessage": "Invalid Value",
           "default": "30",
           "placeholder": "e.g: 30"
+        },
+        {
+          "type": "connectionMode",
+          "configKey": "useNativeSDK",
+          "label": "",
+          "sourceType": "",
+          "value": false,
+          "disabled": false
         }
       ]
     }


### PR DESCRIPTION
## Description of the change

 Reverting an unwanted change, adding connectionMode field back to uiConfig

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
