### PR TITLE
feat: add validation for destination definition

### DIFF
--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -92,8 +92,7 @@ export function validateHybridModeCloudConfig(destinationDefinition: any): boole
     return { isValid: true, valList: subsetValues };
   };
   if (destinationDefinition?.config?.hybridModeCloudEventsFilter) {
-    const hybridModeCloudEventsFilter = destinationDefinition?.config?.hybridModeCloudEventsFilter;
-    const supportedSourceTypes = destinationDefinition?.config?.supportedSourceTypes;
+    const { hybridModeCloudEventsFilter, supportedSourceTypes } = destinationDefinition.config;
 
     const { isValid: isSourceTypeValid, valList: sourceTypes } =
       checkForValidaObjectAndValidateWithMasterList(
@@ -132,7 +131,7 @@ export function validateHybridModeCloudConfig(destinationDefinition: any): boole
 
       // basic-check
       return eventProperties.some((eventProperty) =>
-        Array.isArray(sourceTypeFilterMap?.[eventProperty]),
+        Array.isArray(sourceTypeFilterMap[eventProperty]),
       );
     });
   }
@@ -147,7 +146,7 @@ export async function validateDestinationDefinitions(destName: string): Promise<
   return isValidHybridModeCloudConfig;
 }
 
-export function validateSourceType(sourceDefinition: Record<string, any>) {
+export function validateSourceType(sourceDefinition: any) {
   // currently these are the valid source-types according to the ServiceUtil.getSourceType logic in config-backend
   const validSourceTypes = [
     'cloud',

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -225,6 +225,25 @@ describe('Destination Definition wrong configuration tests', () => {
       expect(isValid).toBe(testCase.expected);
     });
   });
+
+  it('should return true, destinationDefinition is undefined', () => {
+    expect(validateHybridModeCloudConfig(undefined)).toEqual(true);
+  });
+  it('should return true, destinationDefinition.config is undefined', () => {
+    expect(validateHybridModeCloudConfig({ config: undefined })).toEqual(true);
+  });
+  it('should return true, destinationDefinition.config.supportedSourceTypes is undefined', () => {
+    expect(validateHybridModeCloudConfig({ config: { supportedSourceTypes: undefined } })).toEqual(
+      true,
+    );
+  });
+  it('should return true, destinationDefinition.config.hybridModeCloudEventsFilter is undefined', () => {
+    expect(
+      validateHybridModeCloudConfig({
+        config: { supportedSourceTypes, hybridModeCloudEventsFilter: undefined },
+      }),
+    ).toEqual(true);
+  });
 });
 
 describe('Source Definition validation tests', () => {
@@ -236,5 +255,8 @@ describe('Source Definition validation tests', () => {
 
   it('sourceDefinition does not have valid type', () => {
     expect(validateSourceType({ type: 'someSource' })).toEqual(false);
+  });
+  it('sourceDefinition undefined', () => {
+    expect(validateSourceType(undefined)).toEqual(false);
   });
 });


### PR DESCRIPTION
## Description of the change

1. Added validation tests for `sourceType` field in `sources/**/db-config.json`
2. Added validation tests for `hybridModeCloudEventsFilter` field in `destinations/**/db-config.json`

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
