### PR TITLE
fix: empty schema for kafka to override config-be validator

### DIFF
--- a/src/configurations/destinations/kafka/schema.json
+++ b/src/configurations/destinations/kafka/schema.json
@@ -1,3 +1,5 @@
 {
-  "configSchema": null
+  "configSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  }
 }

--- a/src/configurations/sources/shopify/db-config.json
+++ b/src/configurations/sources/shopify/db-config.json
@@ -4,6 +4,6 @@
   "displayName": "Shopify",
   "options": {
     "isBeta": false,
-    "hidden": true
+    "hidden": false
   }
 }


### PR DESCRIPTION
## Description of the change

Empty schema for kafka to override config-be validator session having wrong schema validator
Enabling shopify source in webapp

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
