### PR TITLE
fix: embedAvroSchemaID issue

### DIFF
--- a/src/configurations/destinations/kafka/schema.json
+++ b/src/configurations/destinations/kafka/schema.json
@@ -196,7 +196,7 @@
               "boolean": "true"
             }
           },
-          "required": ["avroSchemas", "embedAvroSchemaID"]
+          "required": ["avroSchemas"]
         }
       }
     ],

--- a/test/data/validation/destinations/kafka.json
+++ b/test/data/validation/destinations/kafka.json
@@ -195,7 +195,7 @@
         "schema": "bar"
       }
     },
-    "result": false
+    "result": true
   },
   {
     "config": {


### PR DESCRIPTION
## Description of the change

In prod enterprise customers are unable to create kafka destination, because `rudder-webapp` changes are not yet released. Essentially, schema.json is  expecting `embedAvroSchemaID` from frontend as it is present under `required`. But, since it is not present in UI for kafka enterprise,  schema.json validation would fail. 

This PR fixes it by removing `embedAvroSchemaID ` from `required` field.

issue slack thread ref: https://rudderlabs.slack.com/archives/C02B0A38QQG/p1684263485188099

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
