### PR TITLE
fix: anyOf to be array and schema diff for allOf, anyOf in schema generator script

### DIFF
--- a/scripts/schemaGenerator.py
+++ b/scripts/schemaGenerator.py
@@ -752,7 +752,10 @@ def generate_schema(uiConfig, dbConfig, name, selector):
     if allOfSchemaObj:
         # AnyOf occuring separately, not inside of allOf.
         if len(allOfSchemaObj) == 1:
-            schemaObject['anyOf'] = allOfSchemaObj[0]
+           if isinstance(allOfSchemaObj[0], list):
+               schemaObject['anyOf'] = allOfSchemaObj[0]
+           else:
+               schemaObject['anyOf'] = allOfSchemaObj
         else:
             schemaObject['allOf'] = allOfSchemaObj
     generate_schema_properties(uiConfig, dbConfig, schemaObject,
@@ -865,15 +868,19 @@ def validate_config_consistency(name, selector, uiConfig, dbConfig, schema):
             # call for individual warnings
             for uiType in uiTypetoSchemaFn.keys():
                 generate_warnings_for_each_type(uiConfig, dbConfig, schema, uiType)
-            if "allOf" in schema:
-                curAllOfSchema = schema["allOf"]
-                newAllOfSchema = generate_schema_for_allOf(uiConfig, dbConfig, "value")
+            if "allOf" in generatedSchema["configSchema"]:
+                curAllOfSchema = {}
+                if "allOf" in schema:
+                    curAllOfSchema = schema["allOf"]
+                newAllOfSchema = generatedSchema["configSchema"]["allOf"]
                 allOfSchemaDiff = diff(newAllOfSchema, curAllOfSchema)
                 if allOfSchemaDiff:
                     warnings.warn("For allOf field Difference is :  \n\n {} \n".format(allOfSchemaDiff), UserWarning)
-            if "anyOf" in schema:
-                curAnyOfSchema = schema["anyOf"]
-                newAnyOfSchema = generate_schema_for_allOf(uiConfig, dbConfig, "value")
+            if "anyOf" in generatedSchema["configSchema"]:
+                curAnyOfSchema = {}
+                if "anyOf" in schema:
+                    curAnyOfSchema = schema["anyOf"]
+                newAnyOfSchema = generatedSchema["configSchema"]["anyOf"]
                 anyOfSchemaDiff = diff(newAnyOfSchema, curAnyOfSchema)
                 if anyOfSchemaDiff:
                     warnings.warn("For anyOf field Difference is :  \n\n {} \n".format(anyOfSchemaDiff), UserWarning)


### PR DESCRIPTION
## Description of the change

The PR fixes the  following issues 
1.  `anyOf` schema getting generated as `object` rather than `array` in schema by `schemaGenerator.py` script.
2.  Fixes the schema diff for `allOf` and `anyOf` when original schema does not have `allOf` and `anyOf` properties.

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
