### PR TITLE
fix: fix schema generator script

### DIFF
--- a/scripts/schemaGenerator.py
+++ b/scripts/schemaGenerator.py
@@ -805,11 +805,6 @@ def generate_schema(uiConfig, dbConfig, name, selector):
     generate_schema_properties(uiConfig, dbConfig, schemaObject,
                        schemaObject['properties'], name, selector)
     newSchema['configSchema'] = schemaObject
-    file_path = '/Users/rudderstack/workspace/rudder-config-schema/src/configurations/destinations/adobe_analytics/schema.json'
-    new_content = json.dumps(newSchema)
-    with open(file_path, 'w') as file:
-        # Write the new content
-        file.write(new_content)
     return newSchema
 
 def generate_warnings_for_each_type(uiConfig, dbConfig, schema, curUiType):


### PR DESCRIPTION
## Description of the change

- Uses enum for ui-fields conatining options. Creates helper strings in meta for options.
- We add default pattern to customFields in dynamicCustomForm despite them not having regex. It should only be added if the customFieldType is String. Otherwise not required.
- Options in dynamicCustomForm to be associated with from and to on basis of reverse.

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
