### PR TITLE
fix(hs):  one trust cookie category form type

### DIFF
--- a/src/configurations/destinations/hs/ui-config.json
+++ b/src/configurations/destinations/hs/ui-config.json
@@ -213,20 +213,15 @@
       "title": "Consent Settings",
       "fields": [
         {
-          "type": "mappingRows",
+          "type": "dynamicCustomForm",
+          "value": "oneTrustCookieCategories",
           "label": "OneTrust Cookie Categories",
-          "columns": [
+          "customFields": [
             {
               "type": "textInput",
               "placeholder": "Marketing",
               "value": "oneTrustCookieCategory",
-              "label": "Category Name/ID",
-              "required": false
-            },
-            {
-              "type": "textInput",
-              "placeholder": "Marketing",
-              "value": "oneTrustCookieCategory",
+              "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
               "label": "Category Name/ID",
               "required": false
             }


### PR DESCRIPTION
## Description of the change

- One trust cookie category type should be `dynamicCustomForm`

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
