### PR TITLE
fix: increase keen's write key size constraint to 250

### DIFF
--- a/src/configurations/destinations/keen/ui-config.json
+++ b/src/configurations/destinations/keen/ui-config.json
@@ -16,7 +16,7 @@
           "type": "textInput",
           "label": "Write Key",
           "value": "writeKey",
-          "regex": "^(.{0,100})$",
+          "regex": "^(.{0,250})$",
           "regexErrorMessage": "Invalid Write Key",
           "required": true
         }


### PR DESCRIPTION
## Description of the change

Keen's write key is more than the current set size constraint of 100 characters. We are fixing it here

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
