### PR TITLE
fix: make bingAds aud visible and add message type to marketo bulk upload

### DIFF
--- a/src/configurations/destinations/bingads_audience/db-config.json
+++ b/src/configurations/destinations/bingads_audience/db-config.json
@@ -30,7 +30,5 @@
       ]
     }
   },
-  "options": {
-    "hidden": true
-  }
+  "options": { "isBeta": true }
 }

--- a/src/configurations/destinations/marketo_bulk_upload/db-config.json
+++ b/src/configurations/destinations/marketo_bulk_upload/db-config.json
@@ -20,6 +20,7 @@
       "warehouse",
       "shopify"
     ],
+    "supportedMessageTypes": ["identify"],
     "destConfig": {
       "defaultConfig": [
         "clientId",


### PR DESCRIPTION
## Description of the change

resolves INT-244
resolves INT-157

- making bingAds audience visible with beta tag
- adding supported message type Identify for marketo bulk upload

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
