### PR TITLE
feat(INT-523): update customerIo UI config to convert datacenter field t dropdown

### DIFF
--- a/src/configurations/destinations/customerio/db-config.json
+++ b/src/configurations/destinations/customerio/db-config.json
@@ -10,7 +10,7 @@
     "includeKeys": [
       "apiKey",
       "siteID",
-      "datacenterEU",
+      "datacenter",
       "blacklistedEvents",
       "whitelistedEvents",
       "oneTrustCookieCategories",
@@ -36,7 +36,7 @@
       "defaultConfig": [
         "apiKey",
         "siteID",
-        "datacenterEU",
+        "datacenter",
         "deviceTokenEventName",
         "blacklistedEvents",
         "whitelistedEvents",

--- a/src/configurations/destinations/customerio/schema.json
+++ b/src/configurations/destinations/customerio/schema.json
@@ -1,10 +1,7 @@
 {
   "configSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "required": [
-      "siteID",
-      "apiKey"
-    ],
+    "required": ["siteID", "apiKey"],
     "type": "object",
     "properties": {
       "siteID": {
@@ -19,9 +16,10 @@
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
       },
-      "datacenterEU": {
-        "type": "boolean",
-        "default": false
+      "datacenter": {
+        "type": "string",
+        "enum": ["US", "EU"],
+        "default": "US"
       },
       "sendPageNameInSDK": {
         "type": "object",
@@ -41,11 +39,7 @@
       },
       "eventFilteringOption": {
         "type": "string",
-        "enum": [
-          "disable",
-          "whitelistedEvents",
-          "blacklistedEvents"
-        ],
+        "enum": ["disable", "whitelistedEvents", "blacklistedEvents"],
         "default": "disable"
       },
       "whitelistedEvents": {

--- a/src/configurations/destinations/customerio/ui-config.json
+++ b/src/configurations/destinations/customerio/ui-config.json
@@ -33,21 +33,21 @@
         {
           "type": "singleSelect",
           "label": "Data Center",
-          "value": "datacenterEU",
+          "value": "datacenter",
           "mode": "single",
           "options": [
             {
               "name": "US",
-              "value": false
+              "value": "US"
             },
             {
               "name": "EU",
-              "value": true
+              "value": "EU"
             }
           ],
           "defaultOption": {
             "name": "US",
-            "value": true
+            "value": "US"
           },
           "footerNote": "Select your Customer.io Data Center"
         },

--- a/test/data/validation/destinations/customerio.json
+++ b/test/data/validation/destinations/customerio.json
@@ -4,7 +4,7 @@
       "siteID": "95bd1331112976i0ff9b",
       "apiKey": "95bd1331112976i0ff9b",
       "deviceTokenEventName": "device_token_registered",
-      "datacenterEU": false,
+      "datacenter": "US",
       "eventFilteringOption": "disable",
       "whitelistedEvents": [
         {
@@ -34,7 +34,7 @@
     "config": {
       "apiKey": "95bd1331112976i0ff9b",
       "deviceTokenEventName": "device_token_registered",
-      "datacenterEU": false,
+      "datacenter": "US",
       "eventFilteringOption": "whitelistedEvents",
       "whitelistedEvents": [
         {
@@ -59,16 +59,14 @@
       ]
     },
     "result": false,
-    "err": [
-      " must have required property 'siteID'"
-    ]
+    "err": [" must have required property 'siteID'"]
   },
   {
     "config": {
       "siteID": "95bd1331112976i0ff9b",
       "apiKey": "95bd1330072974f0ff9b",
       "deviceTokenEventName": "device_location_registered",
-      "datacenterEU": true,
+      "datacenter": "EU",
       "whitelistedEvents": [
         {
           "eventName": "practice"
@@ -98,14 +96,11 @@
       "siteID": "15bd1331112976i0ff9b",
       "apiKey": "15bd1331112976i0ff9b",
       "deviceTokenEventName": "device_id_removed",
-      "datacenterEU": false,
+      "datacenter": "US",
       "eventFilteringOption": "disable",
       "whitelistedEvents": [
         {
-          "eventName": [
-            "e1",
-            "v1"
-          ]
+          "eventName": ["e1", "v1"]
         }
       ],
       "blacklistedEvents": [
@@ -126,16 +121,14 @@
       ]
     },
     "result": false,
-    "err": [
-      "whitelistedEvents.0.eventName must be string"
-    ]
+    "err": ["whitelistedEvents.0.eventName must be string"]
   },
   {
     "config": {
       "siteID": "95bd1331112976i0ff9b",
       "apiKey": "95bd1331112976i0ff9b",
       "deviceTokenEventName": "device_token_registered",
-      "datacenterEU": "Germany",
+      "datacenter": "EU",
       "eventFilteringOption": "disable",
       "useNativeSDK": {
         "web": false
@@ -149,17 +142,14 @@
         }
       ]
     },
-    "result": false,
-    "err": [
-      "datacenterEU must be boolean"
-    ]
+    "result": true
   },
   {
     "config": {
       "siteID": "95bd1331112976i0ff9b",
       "apiKey": "95bd1331112976i0ff9b",
       "deviceTokenEventName": "qwsafpmznjhbfjhchdgeiuudhwgvdfkzxuiookaghhrytedhgfgjslalapooiqnbvemixuhevvsjklodjdokhuijghqwnvzxccdwsalkijediwhfwibkjnkji",
-      "datacenterEU": true,
+      "datacenter": "EU",
       "eventFilteringOption": "disable",
       "useNativeSDK": {
         "web": false


### PR DESCRIPTION
## Description of the change

For selecting regions we are following drop down in general but not in customerIO. This PR converts the `dataCenterEU` flag to DropDown for selecting the region.
Refer to following screenshot for the updated format
<img width="915" alt="Screenshot 2023-09-04 at 11 00 14 AM" src="https://github.com/rudderlabs/rudder-integrations-config/assets/62471433/15f6e843-c710-4b7c-ab15-d4e48862359d">


## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
