### PR TITLE
fix: add "inputFieldType":"password" in databricks token

### DIFF
--- a/src/configurations/sources/databricks/ui-config.json
+++ b/src/configurations/sources/databricks/ui-config.json
@@ -49,7 +49,8 @@
           "regexErrorMessage": "Invalid Value",
           "required": true,
           "addInAccountSummary": false,
-          "secret": true
+          "secret": true,
+          "inputFieldType":"password"
         },
         {
           "type": "textInput",


### PR DESCRIPTION
## Description of the change

Bug: input `token` ub databricks's (source) account is not masked.
Part of RUD-762

https://linear.app/rudderstack/issue/RUD-762/fyi-when-we-verify-credentials-in-databricks-we-expose-the-token-value

## Approach

Added "inputFieldType":"password" for the token field.

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
