### PR TITLE
feat: add new customer acquisition reporting to google ads

### DIFF
--- a/src/configurations/destinations/googleads/db-config.json
+++ b/src/configurations/destinations/googleads/db-config.json
@@ -26,7 +26,8 @@
       "enableDynamicRemarketingEventsFiltering",
       "eventsToTrackDynamicRemarketing",
       "allowEnhancedConversions",
-      "enableConversionLabel"
+      "enableConversionLabel",
+      "newCustomer"
     ],
     "excludeKeys": [],
     "supportedSourceTypes": ["web"],
@@ -52,10 +53,12 @@
         "eventFilteringOption",
         "allowEnhancedConversions",
         "oneTrustCookieCategories",
-        "enableConversionLabel"
+        "enableConversionLabel",
+        "newCustomer"
       ],
       "web": [
         "useNativeSDK",
+        "newCustomer",
         "dynamicRemarketing"
       ]
     },

--- a/src/configurations/destinations/googleads/schema.json
+++ b/src/configurations/destinations/googleads/schema.json
@@ -103,6 +103,10 @@
           }
         }
       },
+      "newCustomer": {
+        "type": ["boolean", "string"],
+        "default": "unspecified"
+      },
       "sendPageView": { "type": "boolean", "default": true },
       "conversionLinker": { "type": "boolean", "default": true },
       "disableAdPersonalization": { "type": "boolean", "default": false },

--- a/src/configurations/destinations/googleads/ui-config.json
+++ b/src/configurations/destinations/googleads/ui-config.json
@@ -61,6 +61,29 @@
               "value": "purchase"
             }
           ]
+        },
+        {
+          "type": "singleSelect",
+          "value": "newCustomer",
+          "required": false,
+          "options": [
+            {
+              "name": "true",
+              "value": true
+            },
+            {
+              "name": "false",
+              "value": false
+            },
+            {
+              "name": "Unspecified",
+              "value": "unspecified"
+            }
+          ],
+          "defaultOption": {
+            "name": "Unspecified",
+            "value": "unspecified"
+          }
         }
       ]
     },


### PR DESCRIPTION
## Description of the change

Resolves INT-445
> Onboarding config changes for new customer acquisition reporting in google ads.

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
