### PR TITLE
fix: change value of a config in ui

### DIFF
--- a/src/configurations/destinations/mp/ui-config.json
+++ b/src/configurations/destinations/mp/ui-config.json
@@ -127,7 +127,7 @@
         {
           "type": "checkbox",
           "label": "Ignore \"Do Not Track\"",
-          "value": "strictMode",
+          "value": "ignoreDnt",
           "default": false,
           "footerNote": "If enabled, Mixpanel will ignore \"Do Not Track\" setting of browser"
         }


### PR DESCRIPTION
## Description of the change

We are mistakenly considering the value of strictMode in place of ignoreDnt for Mixpanel

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
