### PR TITLE
fix: replace hubspot with ortto in title (typo)

### DIFF
--- a/src/configurations/destinations/ortto/ui-config.json
+++ b/src/configurations/destinations/ortto/ui-config.json
@@ -144,7 +144,7 @@
         "fields": [
           {
             "type": "dynamicCustomForm",
-            "label": "Map RudderStack event name to HubSpot Custom Behavioral event name",
+            "label": "Map RudderStack event name to Ortto Custom event name",
             "configKey": "orttoEventsMapping",
             "rowFields": [
               {


### PR DESCRIPTION
## Description of the change

- replace hubspot with ortto in title (typo)

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
