### PR TITLE
fix(ortto): add privateApiKey to secret fields

### DIFF
--- a/src/configurations/destinations/ortto/db-config.json
+++ b/src/configurations/destinations/ortto/db-config.json
@@ -44,7 +44,8 @@
         "eventProperties",
         "oneTrustCookieCategories"
       ]
-    }
+    },
+    "secretKeys": ["privateApiKey"]
   },
   "options": {
     "isBeta": true

--- a/src/configurations/destinations/ortto/ui-config.json
+++ b/src/configurations/destinations/ortto/ui-config.json
@@ -19,7 +19,8 @@
                     "configKey": "privateApiKey",
                     "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,300})$",
                     "regexErrorMessage": "Invalid Api Key",
-                    "placeholder": "e.g: PRV-dummy--dsfsdfsdfsd72fs3UQ6hxfybiDAwg"
+                    "placeholder": "e.g: PRV-dummy--dsfsdfsdfsd72fs3UQ6hxfybiDAwg",
+                    "secret": true
                   },
                   {
                     "type": "singleSelect",


### PR DESCRIPTION
## Description of the change

-Add privateApiKey to secret fields for Ortto destination

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
