### PR TITLE
fix: rename launchdarky audience to launchdarkly segment destination

### DIFF
--- a/src/configurations/destinations/launchdarkly_audience/db-config.json
+++ b/src/configurations/destinations/launchdarkly_audience/db-config.json
@@ -1,6 +1,6 @@
 {
   "name": "LAUNCHDARKLY_AUDIENCE",
-  "displayName": "LaunchDarkly Audience",
+  "displayName": "LaunchDarkly Segment",
   "config": {
     "cdkV2Enabled": true,
     "transformAt": "processor",

--- a/src/configurations/destinations/launchdarkly_audience/ui-config.json
+++ b/src/configurations/destinations/launchdarkly_audience/ui-config.json
@@ -39,20 +39,20 @@
                   },
                   {
                     "type": "textInput",
-                    "label": "Audience ID",
-                    "note": "Enter the Audience ID that you want to sync. This will be mapped to LaunchDarkly's Cohort ID. A Segment (or Audience or Cohort) will be created/updated in LaunchDarkly with this ID.",
+                    "label": "Segment ID",
+                    "note": "Enter the Segment ID that you want to sync. This will be mapped to LaunchDarkly's Cohort ID. A Segment or Cohort will be created/updated in LaunchDarkly with this ID.",
                     "configKey": "audienceId",
                     "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$",
-                    "regexErrorMessage": "Invalid Audience Id",
-                    "placeholder": "e.g: example-audience-id"
+                    "regexErrorMessage": "Invalid Segment Id",
+                    "placeholder": "e.g: example-segment-id"
                   },
                   {
                     "type": "textInput",
-                    "label": "Audience Name",
-                    "note": "Enter the Audience name that you want to sync. This will be mapped to LaunchDarkly's Cohort Name.",
+                    "label": "Segment Name",
+                    "note": "Enter the Segment name that you want to sync. This will be mapped to LaunchDarkly's Cohort Name.",
                     "configKey": "audienceName",
                     "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$",
-                    "regexErrorMessage": "Invalid Audience Name",
+                    "regexErrorMessage": "Invalid Segment Name",
                     "placeholder": "e.g: Logged in users"
                   }
                 ]
@@ -92,18 +92,18 @@
                 "fields": [
                   {
                     "type": "textInput",
-                    "label": "Audience Type",
+                    "label": "Segment Type",
                     "note": [
-                      "Enter the Audience Type. This will be mapped to LaunchDarkly's ",
+                      "Enter the Segment Type. This will be mapped to LaunchDarkly's ",
                       {
                         "text": "Context Kind .",
                         "link": "https://docs.launchdarkly.com/home/contexts/context-kinds"
                       },
-                      "By default, a Segment (or Audience or Cohort) will be created with 'user' as the context kind."
+                      "By default, a Segment or Cohort will be created with 'user' as the context kind."
                     ],
                     "configKey": "audienceType",
                     "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
-                    "regexErrorMessage": "Invalid Audience Type",
+                    "regexErrorMessage": "Invalid Segment Type",
                     "placeholder": "e.g: user"
                   }
                 ]


### PR DESCRIPTION
## Description of the change

Renaming the destination to LaunchDarkly Segment.

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
