### PR TITLE
fix: remove supportedMessageTypes for webhook

### DIFF
--- a/src/configurations/destinations/webhook/db-config.json
+++ b/src/configurations/destinations/webhook/db-config.json
@@ -33,9 +33,6 @@
       "cordova": ["cloud"],
       "shopify": ["cloud"]
     },
-    "supportedMessageTypes": {
-      "cloud": ["identify", "page", "screen", "track", "alias", "group"]
-    },
     "destConfig": {
       "defaultConfig": ["webhookUrl", "webhookMethod", "headers", "oneTrustCookieCategories"]
     },


### PR DESCRIPTION
## Description of the change

- Remove `supportedMessageTypes` for webhook destination

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] I have executed schemaGenerator tests and updated schema if needed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
