### PR TITLE
chore: remove deprecated field transformAt and add supportedMessageTypes

### DIFF
--- a/scripts/template-db-config.json
+++ b/scripts/template-db-config.json
@@ -2,7 +2,6 @@
   "name": "",
   "displayName": "",
   "config": {
-    "transformAt": "processor",
     "transformAtV1": "processor",
     "saveDestinationResponse": false,
     "includeKeys": [],
@@ -19,7 +18,8 @@
       "cordova",
       "warehouse"
     ],
-    "supportedConnectionModes": [],
+    "supportedMessageTypes": {},
+    "supportedConnectionModes": {},
     "destConfig": {
       "defaultConfig": []
     },


### PR DESCRIPTION
## Description of the change

- Remove deprecated field `transformAt` and add `supportedMessageTypes` field from template-db-config file

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] I have executed schemaGenerator tests and updated schema if needed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
