### PR TITLE
fix(ortto): updated default for orttoPersonAttributes.type to "text" from ["text"]

### DIFF
--- a/src/configurations/destinations/ortto/ui-config.json
+++ b/src/configurations/destinations/ortto/ui-config.json
@@ -249,7 +249,7 @@
                         "value": "object"
                       }
                     ],
-                    "default": ["text"]
+                    "default": "text"
                   }
                 ]
               }
@@ -335,7 +335,7 @@
                     "value": "object"
                   }
                 ],
-                "default": ["text"]
+                "default": "text"
               }
             ]
           }


### PR DESCRIPTION
## Description of the change

Resolves INT-1262
Default for `orttoPersonAttributes.type` was set to `["type"]` instead of `"type"` causing issue while submitting the form as schema check will be failing. [Slack thread](https://rudderlabs.slack.com/archives/C02A3UAU9UN/p1703703540277559)

## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] I have executed schemaGenerator tests and updated schema if needed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
