### PR TITLE
fix: make accessToken required only for cloud mode

### DIFF
--- a/src/configurations/destinations/facebook_pixel/schema.json
+++ b/src/configurations/destinations/facebook_pixel/schema.json
@@ -8,10 +8,6 @@
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"
       },
-      "accessToken": {
-        "type": "string",
-        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,300})$"
-      },
       "categoryToContent": {
         "type": "array",
         "items": {
@@ -726,6 +722,35 @@
           }
         }
       }
-    }
+    },
+    "allOf": [
+      {
+        "if": {
+          "not": {
+            "properties": {
+              "connectionMode": {
+                "type": "object",
+                "properties": {
+                  "web": {
+                    "type": "string",
+                    "enum": ["device"]
+                  }
+                }
+              }
+            },
+            "required": ["connectionMode"]
+          }
+        },
+        "then": {
+          "properties": {
+            "accessToken": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,300})$"
+            }
+          },
+          "required": ["accessToken"]
+        }
+      }
+    ]
   }
 }

--- a/src/configurations/destinations/facebook_pixel/ui-config.json
+++ b/src/configurations/destinations/facebook_pixel/ui-config.json
@@ -26,7 +26,7 @@
                     "label": "Business Access Token",
                     "note": "Your Business Access token from your Business Account. Required for cloud-mode.",
                     "configKey": "accessToken",
-                    "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,300})$",
+                    "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,300})$",
                     "regexErrorMessage": "Invalid Business Access Token",
                     "placeholder": "e.g: EAALPFdyOVl4BAKEXmVR...",
                     "secret": true,

--- a/test/data/validation/destinations/facebook_pixel.json
+++ b/test/data/validation/destinations/facebook_pixel.json
@@ -392,5 +392,61 @@
     },
     "result": false,
     "err": ["consentManagement.android.0.provider must be equal to one of the allowed values"]
+  },
+  {
+    "testTitle": "When connectionMode.web is not defined(no source connected or cloud only source connected), accessToken is required",
+    "config": {
+      "pixelId": "471828257250906"
+    },
+    "result": false,
+    "err": [" must have required property 'accessToken'", " must match \"then\" schema"]
+  },
+  {
+    "testTitle": "When connectionMode.web is cloud mode, accessToken is required",
+    "config": {
+      "pixelId": "471828257250906",
+      "connectionMode": {
+        "web": "cloud"
+      }
+    },
+    "result": false,
+    "err": [" must have required property 'accessToken'", " must match \"then\" schema"]
+  },
+  {
+    "testTitle": "When connectionMode.web is in device mode, accessToken is not required",
+    "config": {
+      "pixelId": "471828257250906",
+      "connectionMode": {
+        "web": "device"
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "pixelId": "471828257250906",
+      "accessToken": "ghsrtrtrsjeyry"
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "pixelId": "471828257250906",
+      "accessToken": "ghsrtrtrsjeyry",
+      "connectionMode": {
+        "web": "cloud"
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "pixelId": "471828257250906",
+      "accessToken": "ghsrtrtrsjeyry",
+      "connectionMode": {
+        "web": "device"
+      }
+    },
+    "result": true
   }
 ]


### PR DESCRIPTION
## What are the changes introduced in this PR?

For Facebook Pixel destination, made business access token required only when cloud mode connection exists

## What is the related Linear task?

Resolves INT-1633

## Please explain the objectives of your changes below

<img width="2316" alt="Screenshot 2024-02-22 at 2 10 45 PM" src="https://github.com/rudderlabs/rudder-integrations-config/assets/107025653/bb8bb569-651c-4385-b5f6-7c1a8047b946">
<img width="2315" alt="Screenshot 2024-02-22 at 2 11 19 PM" src="https://github.com/rudderlabs/rudder-integrations-config/assets/107025653/24c1f8e7-4dbb-45c7-a4f5-bf995d198ad8">
<img width="2315" alt="Screenshot 2024-02-22 at 6 16 05 PM" src="https://github.com/rudderlabs/rudder-integrations-config/assets/107025653/a9e787db-8bd8-4dcb-86f4-cf298a4db766">
<img width="2316" alt="Screenshot 2024-02-22 at 6 16 39 PM" src="https://github.com/rudderlabs/rudder-integrations-config/assets/107025653/069025fe-90eb-473a-8e6a-c2ded2c27eaf">


Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
