### PR TITLE
feat: remove categoryToContent mapping field for fb_pixel and fb_conversions

### DIFF
--- a/src/configurations/destinations/facebook_conversions/db-config.json
+++ b/src/configurations/destinations/facebook_conversions/db-config.json
@@ -34,7 +34,6 @@
     "destConfig": {
       "defaultConfig": [
         "blacklistPiiProperties",
-        "categoryToContent",
         "datasetId",
         "eventsToEvents",
         "whitelistPiiProperties",

--- a/src/configurations/destinations/facebook_conversions/schema.json
+++ b/src/configurations/destinations/facebook_conversions/schema.json
@@ -12,22 +12,6 @@
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,500})$"
       },
-      "categoryToContent": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "from": {
-              "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
-            },
-            "to": {
-              "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
-            }
-          }
-        }
-      },
       "eventsToEvents": {
         "type": "array",
         "items": {

--- a/src/configurations/destinations/facebook_conversions/ui-config.json
+++ b/src/configurations/destinations/facebook_conversions/ui-config.json
@@ -302,32 +302,6 @@
       "customEventMapping": {
         "tabs": [
           {
-            "name": "Category mapping",
-            "fields": [
-              {
-                "type": "mapping",
-                "label": "Map your RudderStack Categories to Facebook Content Types",
-                "note": "Input the RudderStack category to map to Facebook's content type.",
-                "configKey": "categoryToContent",
-                "default": [],
-                "columns": [
-                  {
-                    "type": "textInput",
-                    "key": "from",
-                    "label": "RudderStack Category",
-                    "placeholder": "e.g: Product Searched"
-                  },
-                  {
-                    "type": "textInput",
-                    "key": "to",
-                    "label": "Facebook Content Type",
-                    "placeholder": "e.g: Product"
-                  }
-                ]
-              }
-            ]
-          },
-          {
             "name": "Custom event",
             "fields": [
               {

--- a/src/configurations/destinations/facebook_pixel/db-config.json
+++ b/src/configurations/destinations/facebook_pixel/db-config.json
@@ -55,7 +55,6 @@
     "destConfig": {
       "defaultConfig": [
         "blacklistPiiProperties",
-        "categoryToContent",
         "pixelId",
         "eventsToEvents",
         "valueFieldIdentifier",

--- a/src/configurations/destinations/facebook_pixel/schema.json
+++ b/src/configurations/destinations/facebook_pixel/schema.json
@@ -8,22 +8,6 @@
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"
       },
-      "categoryToContent": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "from": {
-              "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
-            },
-            "to": {
-              "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
-            }
-          }
-        }
-      },
       "standardPageCall": {
         "type": "boolean",
         "default": false

--- a/src/configurations/destinations/facebook_pixel/ui-config.json
+++ b/src/configurations/destinations/facebook_pixel/ui-config.json
@@ -446,32 +446,6 @@
       "customEventMapping": {
         "tabs": [
           {
-            "name": "Category mapping",
-            "fields": [
-              {
-                "type": "mapping",
-                "label": "Map your RudderStack Categories to Facebook Content Types",
-                "note": "Input the RudderStack category to map to Facebook's content type.",
-                "configKey": "categoryToContent",
-                "default": [],
-                "columns": [
-                  {
-                    "type": "textInput",
-                    "key": "from",
-                    "label": "RudderStack Category",
-                    "placeholder": "e.g: Product Searched"
-                  },
-                  {
-                    "type": "textInput",
-                    "key": "to",
-                    "label": "Facebook Content Type",
-                    "placeholder": "e.g: Product"
-                  }
-                ]
-              }
-            ]
-          },
-          {
             "name": "Custom event",
             "fields": [
               {


### PR DESCRIPTION
## What are the changes introduced in this PR?

Remove categoryToContent mapping field for fb_pixel and fb_conversions

## What is the related Linear task?

Resolves INT-1534

## Please explain the objectives of your changes below

https://www.notion.so/rudderstacks/Category-to-content_type-mapping-issue-a9ce8d8fb78041afa4b04b9bf54ca4c4

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
