### PR TITLE
feat: deprecate mixpanel apiSecret

### DIFF
--- a/src/configurations/destinations/mp/schema.json
+++ b/src/configurations/destinations/mp/schema.json
@@ -8,10 +8,6 @@
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"
       },
-      "apiSecret": {
-        "type": "string",
-        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
-      },
       "serviceAccountUserName": {
         "type": "string"
       },

--- a/src/configurations/destinations/mp/ui-config.json
+++ b/src/configurations/destinations/mp/ui-config.json
@@ -15,16 +15,6 @@
         },
         {
           "type": "textInput",
-          "label": "API Secret",
-          "value": "apiSecret",
-          "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
-          "regexErrorMessage": "Invalid API Secret",
-          "required": false,
-          "placeholder": "f8a911adfbb6XXXXc43cdfe29e912a90",
-          "secret": true
-        },
-        {
-          "type": "textInput",
           "label": "Service Account Username",
           "value": "serviceAccountUserName",
           "required": false


### PR DESCRIPTION
## What are the changes introduced in this PR?

Deprecating the API secret support, As this setting is not required anymore for authentication.
Related : https://github.com/rudderlabs/rudder-transformer/pull/2833

## What is the related Linear task?

Resolves INT-652

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [x] Are sensitive fields marked as secret in definition config?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

### Reviewer checklist

- [x] Is the type of change in the PR title appropriate as per the changes?

- [x] Verified that there are no credentials or confidential data exposed with the changes.
