### PR TITLE
chore: hide active campaign and mailchimp blendo connectors

### DIFF
--- a/src/configurations/sources/active_campaign/db-config.json
+++ b/src/configurations/sources/active_campaign/db-config.json
@@ -2,5 +2,8 @@
   "name": "active_campaign",
   "category": "cloud",
   "displayName": "Active campaign",
-  "type": "cloudSource"
+  "type": "cloudSource",
+  "options": {
+    "hidden": true
+  }
 }

--- a/src/configurations/sources/mailchimp/db-config.json
+++ b/src/configurations/sources/mailchimp/db-config.json
@@ -2,5 +2,8 @@
   "name": "mailchimp",
   "category": "cloud",
   "displayName": "Mailchimp",
-  "type": "cloudSource"
+  "type": "cloudSource",
+  "options": {
+    "hidden": true
+  }
 }


### PR DESCRIPTION
## What are the changes introduced in this PR?

We want to hide 2 Blendo connectors to prevent customers from using them as they are deprecated. 

## What is the related Linear task?

[ticket](https://linear.app/rudderstack/issue/ETL-308/hide-mailchimp-and-active-campaign-sources)
