### PR TITLE
docs: fix broken sample input file link

### DIFF
--- a/oscontrib/README.md
+++ b/oscontrib/README.md
@@ -8,7 +8,7 @@ To contribute a destination, you need to provide all the required data for all t
 
 ## How you can provide your destination connection setting details
 
-You can checkout the sample input file [**here**](https://github.com/rudderlabs/rudder-integrations-config/blob/config-generator-script/test/configData/inputData.json):
+You can checkout the sample input file [**here**](/test/configData/inputData.json):
 
 For the above input data, the UI will look like as shown below:
 


### PR DESCRIPTION
## What are the changes introduced in this PR?

The link to sample input config file in oscontrib guide is broken

## Please explain the objectives of your changes below

Fix the broken link to sample input file

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

GitHub now supports relative links, making it easier to link repo files

### Any new dependencies introduced with this change?

No

### Any new checks got introduced or modified in test suites. Please explain the changes.

No

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [x] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [x] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

### Reviewer checklist

- [x] Is the type of change in the PR title appropriate as per the changes?

- [x] Verified that there are no credentials or confidential data exposed with the changes.
