### PR TITLE
feat: google ads toggle for enhanced conversion fields

### DIFF
--- a/src/configurations/destinations/googleads/db-config.json
+++ b/src/configurations/destinations/googleads/db-config.json
@@ -6,6 +6,7 @@
     "saveDestinationResponse": false,
     "includeKeys": [
       "v2",
+      "allowIdentify",
       "conversionID",
       "eventMappingFromConfig",
       "pageLoadConversions",
@@ -35,6 +36,7 @@
     "destConfig": {
       "defaultConfig": [
         "v2",
+        "allowIdentify",
         "conversionID",
         "eventMappingFromConfig",
         "pageLoadConversions",

--- a/src/configurations/destinations/googleads/schema.json
+++ b/src/configurations/destinations/googleads/schema.json
@@ -5,6 +5,7 @@
     "type": "object",
     "properties": {
       "v2": { "type": "boolean", "default": true },
+      "allowIdentify": { "type": "boolean", "default": false },
       "conversionID": {
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^AW-(.{0,100})$"

--- a/src/configurations/destinations/googleads/ui-config.json
+++ b/src/configurations/destinations/googleads/ui-config.json
@@ -14,6 +14,16 @@
           }
         },
         {
+          "type": "checkbox",
+          "label": "Allow identify calls for the Google Ads destination",
+          "value": "allowIdentify",
+          "default": false,
+          "footerURL": {
+            "link": "https://support.google.com/google-ads/answer/13258081#zippy=%2Cconfigure-your-conversion-page-google-tag",
+            "text": "If enabled, identify calls can be used to define your enhanced conversion fields"
+          }
+        },
+        {
           "type": "textInput",
           "label": "Conversion ID",
           "value": "conversionID",

--- a/test/data/validation/destinations/googleads.json
+++ b/test/data/validation/destinations/googleads.json
@@ -157,6 +157,7 @@
   {
     "config": {
       "conversionID": "AW-12321",
+      "allowIdentify": true,
       "eventFilteringOption": "whitelistedEvents",
       "defaultPageConversion": "poiiopqwewqwwqewq",
       "sendPageView": {


### PR DESCRIPTION
## What are the changes introduced in this PR?

Add toggle for google ads to support enhanced conversion fields via identify calls.
Refer [this](https://support.google.com/google-ads/answer/13258081#zippy=%2Cconfigure-your-conversion-page-google-tag) on how this works

## What is the related Linear task?

Resolves INT-2073

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
