### PR TITLE
chore: add deprecated message for skadNetwork field in Kochava

### DIFF
--- a/src/configurations/destinations/kochava/ui-config.json
+++ b/src/configurations/destinations/kochava/ui-config.json
@@ -26,7 +26,7 @@
           "value": "skAdNetwork",
           "required": false,
           "default": false,
-          "footerNote": "This field is deprecated. It is applicable only for iOS device mode and requires you to configure SKAdNetwork settings for your app on the Kochava dashboard to work as expected."
+          "footerNote": "This field is **DEPRECATED** and making changes to it will not have any effect on the functionality. It is applicable only for iOS device mode and requires you to configure SKAdNetwork settings for your app on the Kochava dashboard to work as expected."
         }
       ]
     },


### PR DESCRIPTION
## What are the changes introduced in this PR?

- In Kochava this `skAdNetwork` field has been removed from their iOS SDK. So to handle this we decided to mark this field as deprecated, instead of removing it completely, as we want to ensure backward compatibility.

<img width="1209" alt="image" src="https://github.com/rudderlabs/rudder-integrations-config/assets/64667840/d6d2e2bd-e333-421e-b43a-fd193e3887c0">

## What is the related Linear task?

Resolves https://linear.app/rudderstack/issue/SDK-1903/disable-the-skad-field-in-the-kochava-webapp.

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
