### PR TITLE
fix: client id override

### DIFF
--- a/src/configurations/destinations/ga4/ui-config.json
+++ b/src/configurations/destinations/ga4/ui-config.json
@@ -413,7 +413,7 @@
               "link": "https://www.rudderstack.com/docs/destinations/streaming-destinations/google-analytics-4/setting-up-google-analytics-4-in-rudderstack/#hybrid-mode"
             }
           ],
-          "default": true
+          "default": false
         }
       ]
     },

--- a/src/configurations/destinations/ga4_v2/db-config.json
+++ b/src/configurations/destinations/ga4_v2/db-config.json
@@ -19,7 +19,6 @@
       "eventFilteringOption",
       "extendPageViewParams",
       "piiPropertiesToIgnore",
-      "overrideClientAndSessionId",
       "oneTrustCookieCategories",
       "ketchConsentPurposes",
       "consentManagement",

--- a/src/configurations/destinations/ga4_v2/ui-config.json
+++ b/src/configurations/destinations/ga4_v2/ui-config.json
@@ -351,27 +351,6 @@
           "configKey": "extendPageViewParams",
           "note": "Enabling this extends the set of properties automatically collected to include 'URL' and 'search'.  Note that GA4 has a limit on the number of unique properties per event name",
           "default": false
-        },
-        {
-          "preRequisites": {
-            "fields": [
-              {
-                "configKey": "connectionMode.web",
-                "value": "hybrid"
-              }
-            ]
-          },
-          "type": "checkbox",
-          "label": "Override gtag client ID & session ID",
-          "configKey": "overrideClientAndSessionId",
-          "note": [
-            "Override the gtag clientID & sessionID with RudderStack's to ensure attribution is properly unified across page and track events. We recommend turning on the override function. Otherwise, instrument your RudderStack SDK based on instructions ",
-            {
-              "text": "here",
-              "link": "https://www.rudderstack.com/docs/destinations/streaming-destinations/google-analytics-4/setting-up-google-analytics-4-in-rudderstack/#hybrid-mode"
-            }
-          ],
-          "default": true
         }
       ]
     },

--- a/src/configurations/destinations/ga4_v2/ui-config.jt
+++ b/src/configurations/destinations/ga4_v2/ui-config.jt
@@ -351,27 +351,6 @@
           "configKey": "extendPageViewParams",
           "note": "Enabling this extends the set of properties automatically collected to include 'URL' and 'search'.  Note that GA4 has a limit on the number of unique properties per event name",
           "default": false
-        },
-        {
-          "preRequisites": {
-            "fields": [
-              {
-                "configKey": "connectionMode.web",
-                "value": "hybrid"
-              }
-            ]
-          },
-          "type": "checkbox",
-          "label": "Override gtag client ID & session ID",
-          "configKey": "overrideClientAndSessionId",
-          "note": [
-            "Override the gtag clientID & sessionID with RudderStack's to ensure attribution is properly unified across page and track events. We recommend turning on the override function. Otherwise, instrument your RudderStack SDK based on instructions ",
-            {
-              "text": "here",
-              "link": "https://www.rudderstack.com/docs/destinations/streaming-destinations/google-analytics-4/setting-up-google-analytics-4-in-rudderstack/#hybrid-mode"
-            }
-          ],
-          "default": true
         }
       ]
     },


### PR DESCRIPTION
## What are the changes introduced in this PR?

Fix for client id session id override which is by default being enabled for ga4 also we dont want to expose it at the moment for ga4_v2
