### PR TITLE
feat: criteo add support for multiple hash methods

### DIFF
--- a/src/configurations/destinations/criteo/schema.json
+++ b/src/configurations/destinations/criteo/schema.json
@@ -14,7 +14,7 @@
       },
       "hashMethod": {
         "type": "string",
-        "enum": ["none", "md5", "sha256"],
+        "enum": ["none", "md5", "sha256", "both"],
         "default": "none"
       },
       "fieldMapping": {

--- a/src/configurations/destinations/criteo/ui-config.json
+++ b/src/configurations/destinations/criteo/ui-config.json
@@ -39,6 +39,10 @@
             {
               "name": "SHA256",
               "value": "sha256"
+            },
+            {
+              "name": "Both",
+              "value": "both"
             }
           ],
           "defaultOption": {

--- a/test/data/validation/destinations/criteo.json
+++ b/test/data/validation/destinations/criteo.json
@@ -44,6 +44,49 @@
   },
   {
     "config": {
+      "accountId": "12",
+      "homePageUrl": "https://www.google.com",
+      "hashMethod": "both",
+      "fieldMapping": [
+        {
+          "from": "signup",
+          "to": "billing"
+        }
+      ],
+      "whitelistedEvents": [
+        {
+          "eventName": "login"
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": "ad_disabled"
+        }
+      ],
+      "eventFilteringOption": "whitelistedEvents",
+      "oneTrustCookieCategories": [
+        {
+          "oneTrustCookieCategory": "product"
+        }
+      ],
+      "eventsToStandard": [
+        {
+          "from": "add to cart",
+          "to": "product viewed"
+        },
+        {
+          "from": "cart checkout",
+          "to": "cart viewed"
+        }
+      ]
+    },
+    "useNativeSDK": {
+      "web": false
+    },
+    "result": true
+  },
+  {
+    "config": {
       "accountId": "",
       "homePageUrl": "https://www.facebook.com",
       "hashMethod": "md5",


### PR DESCRIPTION
## What are the changes introduced in this PR?
Introducing a new option in hash method drop down to use both `md5` and `sha256` methods
Criteo Docs: https://help.criteo.com/kb/guide/en/intro-to-the-criteo-onetag-8fjCDwCENw/Steps/775595,853887,2616497,2616569,2616738,2617588
Write a brief explainer on your code changes.

## What is the related Linear task?

Resolves INT-2438

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
