### PR TITLE
chore(retl:destination:fbca): add vdm-next option

### DIFF
--- a/src/configurations/destinations/fb_custom_audience/db-config.json
+++ b/src/configurations/destinations/fb_custom_audience/db-config.json
@@ -2,6 +2,7 @@
   "name": "FB_CUSTOM_AUDIENCE",
   "displayName": "Facebook Custom Audience",
   "config": {
+    "features": ["vdm-next"],
     "supportsBlankAudienceCreation": true,
     "disableJsonMapper": true,
     "supportsVisualMapper": true,

--- a/src/schemas/destinations/db-config-schema.json
+++ b/src/schemas/destinations/db-config-schema.json
@@ -48,6 +48,17 @@
           "enum": ["processor", "router", "none"],
           "default": "processor"
         },
+        "features": {
+          "type": "array",
+          "title": "list of destination features",
+          "description": "The list of features supported by the destination.",
+          "items": {
+            "type": "string",
+            "enum": ["vdm-next"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
         "saveDestinationResponse": {
           "type": "boolean",
           "title": "Save Destination Response",


### PR DESCRIPTION
## What are the changes introduced in this PR?

Add `vdm-next` feature to the facebook custom audience