### PR TITLE
feat: make legacy consent management fields source type specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,5 @@ git
 
 reports
 .eslintcache
-.vscode
 
 __pycache__

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,14 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Python Debugger: Current File with Arguments",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal",
+      "args": "${command:pickArgs}"
+    },
+    {
       "name": "Run Validations Test",
       "type": "node",
       "request": "launch",

--- a/scripts/legacyConsentConfigMigrator.py
+++ b/scripts/legacyConsentConfigMigrator.py
@@ -1,0 +1,675 @@
+# THIS IS A TEMPORARY SCRIPT TO MIGRATE LEGACY CONSENT CONFIGURATION FIELDS
+# IT NEEDS TO BE DELETED ONCE THE MIGRATION OF ALL THE DESTINATIONS IS DONE
+import os
+import json
+from utils import get_json_from_file, get_formatted_json, is_old_format
+
+
+def update_test_file(supported_source_types, name):
+    test_file_path = f"./test/data/validation/destinations/{name}.json"
+    test_data = []
+    if os.path.exists(test_file_path):
+        test_data = get_json_from_file(test_file_path)
+
+    # Clean up the test cases with existing consent management fields
+    for test in test_data:
+        if (
+            "oneTrustCookieCategories" in test["config"]
+            and type(test["config"]["oneTrustCookieCategories"]) != dict
+        ):
+            del test["config"]["oneTrustCookieCategories"]
+            if "err" in test:
+                test["err"] = [
+                    err for err in test["err"] if "oneTrustCookieCategories" not in err
+                ]
+        if "ketchConsentPurposes" in test["config"] != dict:
+            del test["config"]["ketchConsentPurposes"]
+            if "err" in test:
+                test["err"] = [
+                    err for err in test["err"] if "ketchConsentPurposes" not in err
+                ]
+
+        if "err" in test and len(test["err"]) == 0:
+            del test["err"]
+
+    # Filter all the tests that have legacy consent management fields
+    test_data = [
+        test
+        for test in test_data
+        if "oneTrustCookieCategories" not in test["config"]
+        and "ketchConsentPurposes" not in test["config"]
+    ]
+
+    # Filter invalid tests
+    test_data = [
+        test
+        for test in test_data
+        if ("result" in test and test["result"] is not False)
+        or ("err" in test and len(test["err"]) > 0)
+    ]
+
+    success_test = {"config": {}}
+    # Find a successful test case to clone
+    for test in test_data:
+        if test.get("result", False) and not test.get("err", None):
+            success_test = test
+            break
+
+    # Positive test cases for oneTrustCookieCategories and ketchConsentPurposes
+    # exploring different data formats and types
+    one_trust_success_scenarios = [
+        [{"oneTrustCookieCategory": "C0001"}, {"oneTrustCookieCategory": "C0002"}],
+        [{"oneTrustCookieCategory": "C0003"}, {"oneTrustCookieCategory": "C0004"}],
+        [{"oneTrustCookieCategory": ""}],
+        [],
+        [{"oneTrustCookieCategory": "env.ENVIRONMENT_VARIABLE"}],
+        [
+            {
+                "oneTrustCookieCategory": "{"
+                + "{"
+                + " event.properties.prop1 || 'val' "
+                + "}"
+                + "}"
+            }
+        ],
+    ]
+
+    ketch_success_scenarios = [
+        [{"purpose": "P1"}, {"purpose": "P2"}],
+        [{"purpose": "P3"}, {"purpose": "P4"}],
+        [{"purpose": ""}],
+        [],
+        [{"purpose": "env.ENVIRONMENT_VARIABLE"}],
+        [{"purpose": "{" + "{" + " event.properties.prop1 || 'val' " + "}" + "}"}],
+    ]
+
+    # Prepare the test cases involving each source type
+    s_idx = 0
+    while s_idx < len(one_trust_success_scenarios):
+        # Clone the successful test case and update the consent management fields
+        success_test_clone = json.loads(json.dumps(success_test))
+
+        success_test_clone["config"]["oneTrustCookieCategories"] = {}
+        success_test_clone["config"]["ketchConsentPurposes"] = {}
+
+        for source_type in supported_source_types:
+            success_test_clone["config"]["oneTrustCookieCategories"][source_type] = (
+                one_trust_success_scenarios[s_idx % len(one_trust_success_scenarios)]
+            )
+            success_test_clone["config"]["ketchConsentPurposes"][source_type] = (
+                ketch_success_scenarios[s_idx % len(one_trust_success_scenarios)]
+            )
+            s_idx += 1
+
+        success_test_clone["result"] = True
+        test_data.append(success_test_clone)
+
+    # Negative test case where oneTrustCookieCategories and ketchConsentPurposes are not objects
+    # We don't want to repeat this scenario for each source type
+    failure_test_1 = json.loads(json.dumps(success_test))
+    failure_test_1["config"]["oneTrustCookieCategories"] = [
+        {"oneTrustCookieCategory": "C0001"},
+        {"oneTrustCookieCategory": "C0002"},
+    ]
+    failure_test_1["config"]["ketchConsentPurposes"] = [
+        {"purpose": "P1"},
+        {"purpose": "P2"},
+    ]
+    failure_test_1["result"] = False
+    failure_test_1["err"] = [
+        "oneTrustCookieCategories must be object",
+        "ketchConsentPurposes must be object",
+    ]
+
+    test_data.append(failure_test_1)
+
+    # Negative test cases for oneTrustCookieCategories and ketchConsentPurposes
+    one_trust_failure_scenarios = [
+        {
+            "input": [
+                {"someunsupportedkey": "C0001"},
+                {
+                    "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                },
+                {"oneTrustCookieCategory": "C0004"},
+            ],
+            "error": [
+                "oneTrustCookieCategories.ASDF.0 must NOT have additional properties",
+                'oneTrustCookieCategories.ASDF.1.oneTrustCookieCategory must match pattern "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"',
+            ],
+        },
+        {
+            "input": [
+                {"oneTrustCookieCategory": {"not": "a string"}},
+                {"oneTrustCookieCategory": "C0004"},
+            ],
+            "error": [
+                "oneTrustCookieCategories.ASDF.0.oneTrustCookieCategory must be string"
+            ],
+        },
+        {
+            "input": {"not": "an array"},
+            "error": ["oneTrustCookieCategories.ASDF must be array"],
+        },
+        {
+            "input": ["not an object", {"oneTrustCookieCategory": "C0004"}],
+            "error": ["oneTrustCookieCategories.ASDF.0 must be object"],
+        },
+    ]
+
+    ketch_failure_scenarios = [
+        {
+            "input": [
+                {"someunsupportedkey": "P1"},
+                {
+                    "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                },
+                {"purpose": "P4"},
+            ],
+            "error": [
+                "ketchConsentPurposes.ASDF.0 must NOT have additional properties",
+                'ketchConsentPurposes.ASDF.1.purpose must match pattern "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"',
+            ],
+        },
+        {
+            "input": [{"purpose": {"not": "a string"}}, {"purpose": "P4"}],
+            "error": ["ketchConsentPurposes.ASDF.0.purpose must be string"],
+        },
+        {
+            "input": {"not": "an array"},
+            "error": ["ketchConsentPurposes.ASDF must be array"],
+        },
+        {
+            "input": ["not an object", {"purpose": "P4"}],
+            "error": ["ketchConsentPurposes.ASDF.0 must be object"],
+        },
+    ]
+
+    s_idx = 0
+    is_first = True
+    failure_tcs = []
+    while s_idx < len(one_trust_failure_scenarios):
+        failure_test_clone = json.loads(json.dumps(success_test))
+        failure_tcs.append(failure_test_clone)
+
+        failure_test_clone["err"] = []
+        failure_test_clone["config"]["oneTrustCookieCategories"] = {}
+        if is_first:
+            failure_test_clone["config"]["oneTrustCookieCategories"][
+                "someunsupportedsourcetype"
+            ] = [
+                {"oneTrustCookieCategory": "C0001"},
+                {"oneTrustCookieCategory": "C0002"},
+            ]
+            failure_test_clone["err"].append(
+                "oneTrustCookieCategories must NOT have additional properties"
+            )
+            is_first = False
+
+        for source_type in supported_source_types:
+            if s_idx >= len(one_trust_failure_scenarios):
+                break
+            failure_test_clone["config"]["oneTrustCookieCategories"][source_type] = (
+                one_trust_failure_scenarios[s_idx]["input"]
+            )
+            failure_test_clone["err"].extend(
+                [
+                    x.replace("ASDF", source_type)
+                    for x in one_trust_failure_scenarios[s_idx]["error"]
+                ]
+            )
+
+            s_idx += 1
+
+        failure_test_clone["result"] = False
+
+    s_idx = 0
+    is_first = True
+    tc_idx = 0
+    while s_idx < len(ketch_failure_scenarios):
+        failure_test_clone = failure_tcs[tc_idx]
+        tc_idx += 1
+
+        failure_test_clone["config"]["ketchConsentPurposes"] = {}
+        if is_first:
+            failure_test_clone["config"]["ketchConsentPurposes"][
+                "someunsupportedsourcetype"
+            ] = [{"purpose": "P1"}, {"purpose": "P2"}]
+            failure_test_clone["err"].append(
+                "ketchConsentPurposes must NOT have additional properties"
+            )
+            is_first = False
+
+        for source_type in supported_source_types:
+            if s_idx >= len(ketch_failure_scenarios):
+                break
+            failure_test_clone["config"]["ketchConsentPurposes"][source_type] = (
+                ketch_failure_scenarios[s_idx]["input"]
+            )
+            failure_test_clone["err"].extend(
+                [
+                    x.replace("ASDF", source_type)
+                    for x in ketch_failure_scenarios[s_idx]["error"]
+                ]
+            )
+
+            s_idx += 1
+
+        failure_test_clone["result"] = False
+
+        test_data.append(failure_test_clone)
+
+    # write to file
+    with open(test_file_path, "w") as f:
+        f.write(get_formatted_json(test_data))
+
+
+def update_schema_file(supported_source_types, name, dir_path):
+    schema_file = f"./{dir_path}/{name}/schema.json"
+    schema = {}
+
+    if os.path.exists(schema_file):
+        schema = get_json_from_file(schema_file)
+
+    config_schema = None
+    if "configSchema" in schema:
+        config_schema = schema["configSchema"]
+
+    if not config_schema:
+        config_schema = {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {},
+        }
+
+    one_trust_cookie_categories_schema = {}
+    one_trust_cookie_categories_schema["type"] = "object"
+    one_trust_cookie_categories_schema["properties"] = {}
+    for source_type in supported_source_types:
+        one_trust_cookie_categories_schema["properties"][source_type] = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "oneTrustCookieCategory": {
+                        "type": "string",
+                        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+                    }
+                },
+                "additionalProperties": False,
+            },
+        }
+    one_trust_cookie_categories_schema["additionalProperties"] = False
+    config_schema["properties"][
+        "oneTrustCookieCategories"
+    ] = one_trust_cookie_categories_schema
+
+    ketch_consent_schema = {}
+    ketch_consent_schema["type"] = "object"
+    ketch_consent_schema["properties"] = {}
+    for source_type in supported_source_types:
+        ketch_consent_schema["properties"][source_type] = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "purpose": {
+                        "type": "string",
+                        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+                    }
+                },
+                "additionalProperties": False,
+            },
+        }
+    ketch_consent_schema["additionalProperties"] = False
+    config_schema["properties"]["ketchConsentPurposes"] = ketch_consent_schema
+
+    schema["configSchema"] = config_schema
+
+    with open(schema_file, "w") as f:
+        f.write(get_formatted_json(schema))
+
+
+def update_ui_config_file(name, dir_path):
+    ui_config_file = f"./{dir_path}/{name}/ui-config.json"
+    ui_config = get_json_from_file(ui_config_file)
+
+    if is_old_format(ui_config["uiConfig"]):
+        # Search for existing consent settings section
+        consent_settings = None
+        for section in ui_config["uiConfig"]:
+            if "title" in section and section["title"] == "Consent Settings":
+                consent_settings = section
+                break
+
+        gcm_config = None
+        conf_index = -1
+        if consent_settings:
+            # Search for existing GCM settings
+            conf_index = ui_config["uiConfig"].index(consent_settings)
+            for group in consent_settings["fields"]:
+                if "label" in group and group["label"] == "Consent management settings":
+                    gcm_config = group
+                    break
+
+            # and remove the existing consent settings section
+            ui_config["uiConfig"].remove(consent_settings)
+
+        # Standard consent settings section with legacy fields
+        consent_settings = {
+            "title": "Consent Settings",
+            "fields": [
+                {
+                    "type": "dynamicCustomForm",
+                    "value": "oneTrustCookieCategories",
+                    "label": "OneTrust Consent Category IDs",
+                    "footerNote": "The support for category names is deprecated. We recommend using the category IDs instead of the names as IDs are unique and less likely to change over time, making them a more reliable choice.",
+                    "customFields": [
+                        {
+                            "type": "textInput",
+                            "placeholder": "C0001",
+                            "value": "oneTrustCookieCategory",
+                            "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+                            "label": "Category ID",
+                            "required": False,
+                        }
+                    ],
+                    "preRequisites": {
+                        "featureFlags": [
+                            {"configKey": "AMP_enable-gcm", "value": False},
+                            {"configKey": "AMP_enable-gcm"},
+                        ],
+                        "featureFlagsCondition": "or",
+                    },
+                },
+                {
+                    "type": "dynamicCustomForm",
+                    "value": "ketchConsentPurposes",
+                    "label": "Ketch Consent Purpose IDs",
+                    "customFields": [
+                        {
+                            "type": "textInput",
+                            "placeholder": "marketing",
+                            "value": "purpose",
+                            "label": "Purpose ID",
+                            "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+                            "required": False,
+                        }
+                    ],
+                    "preRequisites": {
+                        "featureFlags": [
+                            {"configKey": "AMP_enable-gcm", "value": False},
+                            {"configKey": "AMP_enable-gcm"},
+                        ],
+                        "featureFlagsCondition": "or",
+                    },
+                },
+            ],
+        }
+
+        # Restore the GCM settings if it was present
+        if gcm_config:
+            consent_settings["fields"].append(gcm_config)
+
+        # Restore the new consent settings in the same position
+        # or append it to the end of the uiConfig
+        if conf_index != -1:
+            ui_config["uiConfig"].insert(conf_index, consent_settings)
+        else:
+            ui_config["uiConfig"].append(consent_settings)
+
+    else:
+        configuration_settings = None
+        one_trust_consent_settings_found = False
+        ketch_consent_settings_found = False
+        one_trust_consent_settings = False
+        ketch_consent_settings = False
+        other_settings = None
+        consent_settings = None
+        consent_settings_template = None
+        base_template = ui_config["uiConfig"]["baseTemplate"]
+
+        for key in ui_config["uiConfig"]:
+            if key == "baseTemplate":
+                for template_entry in base_template:
+                    # Search for existing consent settings sections
+                    if (
+                        "title" in template_entry
+                        and template_entry["title"] == "Configuration settings"
+                    ):
+                        configuration_settings = template_entry
+                        for section in template_entry["sections"]:
+                            if (
+                                not other_settings
+                                and "title" in section
+                                and section["title"] == "Other settings"
+                            ):
+                                other_settings = section
+                                for group in section["groups"]:
+                                    if "title" in group and (
+                                        group["title"] == "OneTrust consent settings"
+                                        or group["title"]
+                                        == "OneTrust cookie consent settings"
+                                    ):
+                                        one_trust_consent_settings_found = True
+                                        one_trust_consent_settings = group
+                                    elif (
+                                        "title" in group
+                                        and group["title"] == "Ketch consent settings"
+                                    ):
+                                        ketch_consent_settings_found = True
+                                        ketch_consent_settings = group
+
+                            if (
+                                not consent_settings
+                                and "title" in section
+                                and section["title"] == "Consent settings"
+                            ):
+                                consent_settings = section
+
+                        # Remove the existing consent settings sections
+                        if (
+                            one_trust_consent_settings_found
+                            and one_trust_consent_settings
+                        ):
+                            other_settings["groups"].remove(one_trust_consent_settings)
+
+                        # Remove the existing consent settings sections
+                        if ketch_consent_settings_found and ketch_consent_settings:
+                            other_settings["groups"].remove(ketch_consent_settings)
+            elif not consent_settings_template and key == "consentSettingsTemplate":
+                consent_settings_template = ui_config["uiConfig"][key]
+
+                for field in consent_settings_template["fields"]:
+                    if (
+                        "label" in field
+                        and field["label"] == "OneTrust consent category IDs"
+                    ):
+                        one_trust_consent_settings = field
+                        one_trust_consent_settings_found = True
+                    elif (
+                        "label" in field
+                        and field["label"] == "Ketch consent purpose IDs"
+                    ):
+                        ketch_consent_settings = field
+                        ketch_consent_settings_found = True
+
+                # delete onetrust and ketch consent settings from the template
+                if one_trust_consent_settings_found and one_trust_consent_settings:
+                    consent_settings_template["fields"].remove(
+                        one_trust_consent_settings
+                    )
+                if ketch_consent_settings_found and ketch_consent_settings:
+                    consent_settings_template["fields"].remove(ketch_consent_settings)
+
+        # Standard consent settings section with legacy fields
+        new_consent_settings_section = {
+            "id": "consentSettings",
+            "title": "Consent settings",
+            "note": "Configure consent settings for each provider here",
+            "icon": "settings",
+            "groups": [],
+        }
+
+        if not configuration_settings:
+            configuration_settings = {
+                "title": "Configuration settings",
+                "note": "Manage the settings for your destination",
+                "sections": [new_consent_settings_section],
+            }
+            base_template.append(configuration_settings)
+        else:
+            if consent_settings:
+                configuration_settings["sections"].remove(consent_settings)
+
+            if other_settings:
+                # Insert the new consent settings section before the other settings section
+                other_settings_idx = configuration_settings["sections"].index(
+                    other_settings
+                )
+                configuration_settings["sections"].insert(
+                    other_settings_idx, new_consent_settings_section
+                )
+
+                # Remove the other settings section if it's empty
+                if len(other_settings["groups"]) == 0:
+                    configuration_settings["sections"].remove(other_settings)
+            else:
+                configuration_settings["sections"].append(new_consent_settings_section)
+
+        legacy_fields = [
+            {
+                "type": "tagInput",
+                "label": "OneTrust consent category IDs",
+                "note": "Input your OneTrust category IDs by pressing 'Enter' after each entry. The support for category names is deprecated. We recommend using the category IDs instead of the names as IDs are unique and less likely to change over time, making them a more reliable choice.",
+                "configKey": "oneTrustCookieCategories",
+                "tagKey": "oneTrustCookieCategory",
+                "placeholder": "e.g: C0001",
+                "default": [{"oneTrustCookieCategory": ""}],
+                "preRequisites": {
+                    "featureFlags": [
+                        {"configKey": "AMP_enable-gcm", "value": False},
+                        {"configKey": "AMP_enable-gcm"},
+                    ],
+                    "featureFlagsCondition": "or",
+                },
+            },
+            {
+                "type": "tagInput",
+                "label": "Ketch consent purpose IDs",
+                "note": "Input your Ketch consent purpose IDs by pressing 'Enter' after each entry.",
+                "configKey": "ketchConsentPurposes",
+                "tagKey": "purpose",
+                "placeholder": "e.g: marketing",
+                "default": [{"purpose": ""}],
+                "preRequisites": {
+                    "featureFlags": [
+                        {"configKey": "AMP_enable-gcm", "value": False},
+                        {"configKey": "AMP_enable-gcm"},
+                    ],
+                    "featureFlagsCondition": "or",
+                },
+            },
+        ]
+
+        if not consent_settings_template:
+            consent_settings_template = {
+                "title": "Consent settings",
+                "note": "not visible in the ui",
+                "fields": legacy_fields,
+            }
+            ui_config["uiConfig"]["consentSettingsTemplate"] = consent_settings_template
+        else:
+            legacy_fields.reverse()
+            for field in legacy_fields:
+                consent_settings_template["fields"].insert(0, field)
+
+    with open(ui_config_file, "w") as f:
+        f.write(get_formatted_json(ui_config))
+
+
+def update_db_config_file(name, dir_path):
+    db_config_file = f"./{dir_path}/{name}/db-config.json"
+
+    db_config = get_json_from_file(db_config_file)
+    supported_source_types = db_config["config"]["supportedSourceTypes"]
+
+    default_config = db_config["config"]["destConfig"]["defaultConfig"]
+    if "ketchConsentPurposes" in default_config:
+        default_config.remove("ketchConsentPurposes")
+
+    if "oneTrustCookieCategories" in default_config:
+        default_config.remove("oneTrustCookieCategories")
+
+    db_config["config"]["destConfig"]["defaultConfig"] = default_config
+
+    device_mode_supported = False
+    if "supportedConnectionModes" in db_config["config"]:
+        for source_type in db_config["config"]["supportedConnectionModes"]:
+            if (
+                "device" in db_config["config"]["supportedConnectionModes"][source_type]
+                or "hybrid"
+                in db_config["config"]["supportedConnectionModes"][source_type]
+            ):
+                device_mode_supported = True
+                break
+
+    for source_type in db_config["config"]["destConfig"]:
+        source_type_config = db_config["config"]["destConfig"][source_type]
+        if (
+            "useNativeSDK" in source_type_config
+            or "useNativeSDKToSend" in source_type_config
+        ):
+            device_mode_supported = True
+            break
+
+    if device_mode_supported:
+        include_keys = []
+        if "includeKeys" in db_config["config"]:
+            include_keys = db_config["config"]["includeKeys"]
+        if "oneTrustCookieCategories" not in include_keys:
+            include_keys.append("oneTrustCookieCategories")
+        if "ketchConsentPurposes" not in include_keys:
+            include_keys.append("ketchConsentPurposes")
+
+        db_config["config"]["includeKeys"] = include_keys
+
+    for source_type in supported_source_types:
+        source_type_config = []
+        if source_type in db_config["config"]["destConfig"]:
+            source_type_config = db_config["config"]["destConfig"][source_type]
+        else:
+            print(f"Warning: {source_type} not found in destConfig for {name}")
+
+        if "oneTrustCookieCategories" not in source_type_config:
+            source_type_config.append("oneTrustCookieCategories")
+
+        if "ketchConsentPurposes" not in source_type_config:
+            source_type_config.append("ketchConsentPurposes")
+
+        db_config["config"]["destConfig"][source_type] = source_type_config
+
+    # update the file with new config
+    with open(db_config_file, "w") as f:
+        f.write(get_formatted_json(db_config))
+
+
+def get_supported_source_types(name, dir_path):
+    db_config_file = f"./{dir_path}/{name}/db-config.json"
+    supported_source_types = []
+    db_config = get_json_from_file(db_config_file)
+    supported_source_types = db_config["config"]["supportedSourceTypes"]
+    return supported_source_types
+
+
+def restructure_legacy_consent_fields(dest_names, dir_path):
+    for name in dest_names:
+        # check if name is a directory
+        if not os.path.isdir(f"./{dir_path}/{name}"):
+            continue
+
+        update_db_config_file(name, dir_path)
+        supported_source_types = get_supported_source_types(name, dir_path)
+        update_schema_file(supported_source_types, name, dir_path)
+        update_test_file(supported_source_types, name)
+        update_ui_config_file(name, dir_path)

--- a/scripts/legacyConsentConfigMigrator.py
+++ b/scripts/legacyConsentConfigMigrator.py
@@ -127,15 +127,13 @@ def update_test_file(supported_source_types, name):
     one_trust_failure_scenarios = [
         {
             "input": [
-                {"someunsupportedkey": "C0001"},
                 {
                     "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                 },
                 {"oneTrustCookieCategory": "C0004"},
             ],
             "error": [
-                "oneTrustCookieCategories.ASDF.0 must NOT have additional properties",
-                'oneTrustCookieCategories.ASDF.1.oneTrustCookieCategory must match pattern "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"',
+                'oneTrustCookieCategories.ASDF.0.oneTrustCookieCategory must match pattern "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"',
             ],
         },
         {
@@ -160,15 +158,13 @@ def update_test_file(supported_source_types, name):
     ketch_failure_scenarios = [
         {
             "input": [
-                {"someunsupportedkey": "P1"},
                 {
                     "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                 },
                 {"purpose": "P4"},
             ],
             "error": [
-                "ketchConsentPurposes.ASDF.0 must NOT have additional properties",
-                'ketchConsentPurposes.ASDF.1.purpose must match pattern "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"',
+                'ketchConsentPurposes.ASDF.0.purpose must match pattern "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"',
             ],
         },
         {
@@ -186,7 +182,6 @@ def update_test_file(supported_source_types, name):
     ]
 
     s_idx = 0
-    is_first = True
     failure_tcs = []
     while s_idx < len(one_trust_failure_scenarios):
         failure_test_clone = json.loads(json.dumps(success_test))
@@ -194,17 +189,6 @@ def update_test_file(supported_source_types, name):
 
         failure_test_clone["err"] = []
         failure_test_clone["config"]["oneTrustCookieCategories"] = {}
-        if is_first:
-            failure_test_clone["config"]["oneTrustCookieCategories"][
-                "someunsupportedsourcetype"
-            ] = [
-                {"oneTrustCookieCategory": "C0001"},
-                {"oneTrustCookieCategory": "C0002"},
-            ]
-            failure_test_clone["err"].append(
-                "oneTrustCookieCategories must NOT have additional properties"
-            )
-            is_first = False
 
         for source_type in supported_source_types:
             if s_idx >= len(one_trust_failure_scenarios):
@@ -224,21 +208,12 @@ def update_test_file(supported_source_types, name):
         failure_test_clone["result"] = False
 
     s_idx = 0
-    is_first = True
     tc_idx = 0
     while s_idx < len(ketch_failure_scenarios):
         failure_test_clone = failure_tcs[tc_idx]
         tc_idx += 1
 
         failure_test_clone["config"]["ketchConsentPurposes"] = {}
-        if is_first:
-            failure_test_clone["config"]["ketchConsentPurposes"][
-                "someunsupportedsourcetype"
-            ] = [{"purpose": "P1"}, {"purpose": "P2"}]
-            failure_test_clone["err"].append(
-                "ketchConsentPurposes must NOT have additional properties"
-            )
-            is_first = False
 
         for source_type in supported_source_types:
             if s_idx >= len(ketch_failure_scenarios):
@@ -296,10 +271,8 @@ def update_schema_file(supported_source_types, name, dir_path):
                         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
                     }
                 },
-                "additionalProperties": False,
             },
         }
-    one_trust_cookie_categories_schema["additionalProperties"] = False
     config_schema["properties"][
         "oneTrustCookieCategories"
     ] = one_trust_cookie_categories_schema
@@ -318,10 +291,8 @@ def update_schema_file(supported_source_types, name, dir_path):
                         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
                     }
                 },
-                "additionalProperties": False,
             },
         }
-    ketch_consent_schema["additionalProperties"] = False
     config_schema["properties"]["ketchConsentPurposes"] = ketch_consent_schema
 
     schema["configSchema"] = config_schema

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -53,3 +53,9 @@ def get_json_from_file(filePath):
     """
     with open(filePath, "r") as file:
         return json.loads(file.read().encode("utf-8", "ignore"))
+
+
+def is_old_format(uiConfig):
+    if isinstance(uiConfig, dict):
+        return False
+    return True

--- a/src/configurations/destinations/am/db-config.json
+++ b/src/configurations/destinations/am/db-config.json
@@ -40,7 +40,8 @@
       "userProvidedScreenEventString",
       "useUserDefinedScreenEventName",
       "proxyServerUrl",
-      "consentManagement"
+      "consentManagement",
+      "ketchConsentPurposes"
     ],
     "excludeKeys": [],
     "supportedSourceTypes": [
@@ -100,7 +101,6 @@
         "whitelistedEvents",
         "eventFilteringOption",
         "mapDeviceBrand",
-        "oneTrustCookieCategories",
         "userProvidedPageEventString",
         "useUserDefinedPageEventName",
         "userProvidedScreenEventString",
@@ -116,7 +116,9 @@
         "eventUploadPeriodMillis",
         "trackNewCampaigns",
         "proxyServerUrl",
-        "consentManagement"
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
       ],
       "android": [
         "eventUploadPeriodMillis",
@@ -126,7 +128,9 @@
         "enableLocationListening",
         "trackSessionEvents",
         "useAdvertisingIdForDeviceId",
-        "consentManagement"
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
       ],
       "ios": [
         "eventUploadPeriodMillis",
@@ -135,7 +139,9 @@
         "connectionMode",
         "trackSessionEvents",
         "useIdfaAsDeviceId",
-        "consentManagement"
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
       ],
       "reactnative": [
         "eventUploadPeriodMillis",
@@ -146,7 +152,9 @@
         "trackSessionEvents",
         "useAdvertisingIdForDeviceId",
         "useIdfaAsDeviceId",
-        "consentManagement"
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
       ],
       "flutter": [
         "eventUploadPeriodMillis",
@@ -157,14 +165,46 @@
         "trackSessionEvents",
         "useAdvertisingIdForDeviceId",
         "useIdfaAsDeviceId",
-        "consentManagement"
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
       ],
-      "unity": ["connectionMode", "consentManagement"],
-      "amp": ["connectionMode", "consentManagement"],
-      "cloud": ["connectionMode", "consentManagement"],
-      "warehouse": ["connectionMode", "consentManagement"],
-      "cordova": ["connectionMode", "consentManagement"],
-      "shopify": ["connectionMode", "consentManagement"]
+      "unity": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "amp": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "cloud": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "warehouse": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "cordova": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "shopify": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ]
     },
     "secretKeys": ["apiKey", "apiSecret"]
   }

--- a/src/configurations/destinations/am/schema.json
+++ b/src/configurations/destinations/am/schema.json
@@ -8,7 +8,11 @@
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"
       },
-      "residencyServer": { "type": "string", "enum": ["standard", "EU"], "default": "standard" },
+      "residencyServer": {
+        "type": "string",
+        "enum": ["standard", "EU"],
+        "default": "standard"
+      },
       "proxyServerUrl": {
         "type": "object",
         "properties": {
@@ -18,10 +22,22 @@
           }
         }
       },
-      "trackAllPages": { "type": "boolean", "default": false },
-      "trackCategorizedPages": { "type": "boolean", "default": true },
-      "trackNamedPages": { "type": "boolean", "default": true },
-      "useUserDefinedPageEventName": { "type": "boolean", "default": false },
+      "trackAllPages": {
+        "type": "boolean",
+        "default": false
+      },
+      "trackCategorizedPages": {
+        "type": "boolean",
+        "default": true
+      },
+      "trackNamedPages": {
+        "type": "boolean",
+        "default": true
+      },
+      "useUserDefinedPageEventName": {
+        "type": "boolean",
+        "default": false
+      },
       "userProvidedPageEventString": {
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,200})$"
@@ -82,7 +98,10 @@
           }
         }
       },
-      "enableEnhancedUserOperations": { "type": "boolean", "default": false },
+      "enableEnhancedUserOperations": {
+        "type": "boolean",
+        "default": false
+      },
       "apiSecret": {
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
@@ -91,10 +110,22 @@
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
       },
-      "mapDeviceBrand": { "type": "boolean", "default": false },
-      "trackProductsOnce": { "type": "boolean", "default": false },
-      "trackRevenuePerProduct": { "type": "boolean", "default": false },
-      "useUserDefinedScreenEventName": { "type": "boolean", "default": false },
+      "mapDeviceBrand": {
+        "type": "boolean",
+        "default": false
+      },
+      "trackProductsOnce": {
+        "type": "boolean",
+        "default": false
+      },
+      "trackRevenuePerProduct": {
+        "type": "boolean",
+        "default": false
+      },
+      "useUserDefinedScreenEventName": {
+        "type": "boolean",
+        "default": false
+      },
       "userProvidedScreenEventString": {
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,200})$"
@@ -129,58 +160,253 @@
         }
       },
       "oneTrustCookieCategories": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "oneTrustCookieCategory": {
-              "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+        "type": "object",
+        "properties": {
+          "android": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "ios": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "unity": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "amp": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cloud": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "warehouse": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "reactnative": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "flutter": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cordova": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "shopify": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
       "enableLocationListening": {
         "type": "object",
         "properties": {
-          "android": { "type": "boolean" },
-          "reactnative": { "type": "boolean" },
-          "flutter": { "type": "boolean" }
+          "android": {
+            "type": "boolean"
+          },
+          "reactnative": {
+            "type": "boolean"
+          },
+          "flutter": {
+            "type": "boolean"
+          }
         }
       },
       "trackSessionEvents": {
         "type": "object",
         "properties": {
-          "android": { "type": "boolean" },
-          "ios": { "type": "boolean" },
-          "reactnative": { "type": "boolean" },
-          "flutter": { "type": "boolean" }
+          "android": {
+            "type": "boolean"
+          },
+          "ios": {
+            "type": "boolean"
+          },
+          "reactnative": {
+            "type": "boolean"
+          },
+          "flutter": {
+            "type": "boolean"
+          }
         }
       },
       "useAdvertisingIdForDeviceId": {
         "type": "object",
         "properties": {
-          "android": { "type": "boolean" },
-          "reactnative": { "type": "boolean" },
-          "flutter": { "type": "boolean" }
+          "android": {
+            "type": "boolean"
+          },
+          "reactnative": {
+            "type": "boolean"
+          },
+          "flutter": {
+            "type": "boolean"
+          }
         }
       },
       "useIdfaAsDeviceId": {
         "type": "object",
         "properties": {
-          "ios": { "type": "boolean" },
-          "reactnative": { "type": "boolean" },
-          "flutter": { "type": "boolean" }
+          "ios": {
+            "type": "boolean"
+          },
+          "reactnative": {
+            "type": "boolean"
+          },
+          "flutter": {
+            "type": "boolean"
+          }
         }
       },
-      "attribution": { "type": "object", "properties": { "web": { "type": "boolean" } } },
-      "trackUtmProperties": { "type": "object", "properties": { "web": { "type": "boolean" } } },
-      "trackNewCampaigns": { "type": "object", "properties": { "web": { "type": "boolean" } } },
+      "attribution": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        }
+      },
+      "trackUtmProperties": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        }
+      },
+      "trackNewCampaigns": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        }
+      },
       "unsetParamsReferrerOnNewSession": {
         "type": "object",
-        "properties": { "web": { "type": "boolean" } }
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        }
       },
-      "batchEvents": { "type": "object", "properties": { "web": { "type": "boolean" } } },
+      "batchEvents": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        }
+      },
       "eventUploadPeriodMillis": {
         "type": "object",
         "properties": {
@@ -234,11 +460,21 @@
       "useNativeSDK": {
         "type": "object",
         "properties": {
-          "android": { "type": "boolean" },
-          "ios": { "type": "boolean" },
-          "web": { "type": "boolean" },
-          "reactnative": { "type": "boolean" },
-          "flutter": { "type": "boolean" }
+          "android": {
+            "type": "boolean"
+          },
+          "ios": {
+            "type": "boolean"
+          },
+          "web": {
+            "type": "boolean"
+          },
+          "reactnative": {
+            "type": "boolean"
+          },
+          "flutter": {
+            "type": "boolean"
+          }
         }
       },
       "consentManagement": {
@@ -755,22 +991,208 @@
       "connectionMode": {
         "type": "object",
         "properties": {
-          "web": { "type": "string", "enum": ["cloud", "device"] },
-          "android": { "type": "string", "enum": ["cloud", "device"] },
-          "ios": { "type": "string", "enum": ["cloud", "device"] },
-          "flutter": { "type": "string", "enum": ["cloud", "device"] },
-          "reactnative": { "type": "string", "enum": ["cloud", "device"] },
-          "unity": { "type": "string", "enum": ["cloud"] },
-          "amp": { "type": "string", "enum": ["cloud"] },
-          "cordova": { "type": "string", "enum": ["cloud"] },
-          "shopify": { "type": "string", "enum": ["cloud"] },
-          "cloud": { "type": "string", "enum": ["cloud"] },
-          "warehouse": { "type": "string", "enum": ["cloud"] }
+          "web": {
+            "type": "string",
+            "enum": ["cloud", "device"]
+          },
+          "android": {
+            "type": "string",
+            "enum": ["cloud", "device"]
+          },
+          "ios": {
+            "type": "string",
+            "enum": ["cloud", "device"]
+          },
+          "flutter": {
+            "type": "string",
+            "enum": ["cloud", "device"]
+          },
+          "reactnative": {
+            "type": "string",
+            "enum": ["cloud", "device"]
+          },
+          "unity": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "amp": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "cordova": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "shopify": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "cloud": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "warehouse": {
+            "type": "string",
+            "enum": ["cloud"]
+          }
         }
       },
       "preferAnonymousIdForDeviceId": {
         "type": "object",
-        "properties": { "web": { "type": "boolean" } }
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ketchConsentPurposes": {
+        "type": "object",
+        "properties": {
+          "android": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "ios": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "unity": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "amp": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cloud": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "warehouse": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "reactnative": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "flutter": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cordova": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "shopify": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
       }
     }
   }

--- a/src/configurations/destinations/am/schema.json
+++ b/src/configurations/destinations/am/schema.json
@@ -171,8 +171,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "ios": {
@@ -184,8 +183,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "web": {
@@ -197,8 +195,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "unity": {
@@ -210,8 +207,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "amp": {
@@ -223,8 +219,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cloud": {
@@ -236,8 +231,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "warehouse": {
@@ -249,8 +243,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "reactnative": {
@@ -262,8 +255,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "flutter": {
@@ -275,8 +267,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cordova": {
@@ -288,8 +279,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "shopify": {
@@ -301,12 +291,10 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
-        },
-        "additionalProperties": false
+        }
       },
       "enableLocationListening": {
         "type": "object",
@@ -1057,8 +1045,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "ios": {
@@ -1070,8 +1057,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "web": {
@@ -1083,8 +1069,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "unity": {
@@ -1096,8 +1081,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "amp": {
@@ -1109,8 +1093,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cloud": {
@@ -1122,8 +1105,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "warehouse": {
@@ -1135,8 +1117,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "reactnative": {
@@ -1148,8 +1129,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "flutter": {
@@ -1161,8 +1141,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cordova": {
@@ -1174,8 +1153,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "shopify": {
@@ -1187,12 +1165,10 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
-        },
-        "additionalProperties": false
+        }
       }
     }
   }

--- a/src/configurations/destinations/am/ui-config.json
+++ b/src/configurations/destinations/am/ui-config.json
@@ -438,6 +438,13 @@
             ]
           },
           {
+            "id": "consentSettings",
+            "title": "Consent settings",
+            "note": "Configure consent settings for each provider here",
+            "icon": "settings",
+            "groups": []
+          },
+          {
             "title": "Other settings",
             "note": "Configure advanced RudderStack features here",
             "icon": "otherSettings",
@@ -523,52 +530,6 @@
                     }
                   }
                 ]
-              }
-            ]
-          },
-          {
-            "id": "consentSettings",
-            "title": "Consent settings",
-            "note": "Configure consent settings for each provider here",
-            "icon": "settings",
-            "groups": [
-              {
-                "title": "OneTrust consent settings",
-                "note": [
-                  "Enter your OneTrust consent category IDs if you have them configured. The support for category names is deprecated. We recommend using the category IDs instead of the names as IDs are unique and less likely to change over time, making them a more reliable choice.",
-                  {
-                    "text": "Learn more ",
-                    "link": "https://www.rudderstack.com/docs/sources/event-streams/sdks/consent-manager/onetrust/"
-                  },
-                  "about RudderStack's OneTrust Consent Management feature."
-                ],
-                "fields": [
-                  {
-                    "type": "tagInput",
-                    "label": "Consent categories",
-                    "note": "Input your OneTrust category IDs by pressing 'Enter' after each entry.",
-                    "configKey": "oneTrustCookieCategories",
-                    "tagKey": "oneTrustCookieCategory",
-                    "placeholder": "e.g: C0001",
-                    "default": [
-                      {
-                        "oneTrustCookieCategory": ""
-                      }
-                    ]
-                  }
-                ],
-                "preRequisites": {
-                  "featureFlags": [
-                    {
-                      "configKey": "AMP_enable-gcm",
-                      "value": false
-                    },
-                    {
-                      "configKey": "AMP_enable-gcm"
-                    }
-                  ],
-                  "featureFlagsCondition": "or"
-                }
               }
             ]
           }
@@ -669,6 +630,56 @@
       "title": "Consent settings",
       "note": "not visible in the ui",
       "fields": [
+        {
+          "type": "tagInput",
+          "label": "OneTrust consent category IDs",
+          "note": "Input your OneTrust category IDs by pressing 'Enter' after each entry. The support for category names is deprecated. We recommend using the category IDs instead of the names as IDs are unique and less likely to change over time, making them a more reliable choice.",
+          "configKey": "oneTrustCookieCategories",
+          "tagKey": "oneTrustCookieCategory",
+          "placeholder": "e.g: C0001",
+          "default": [
+            {
+              "oneTrustCookieCategory": ""
+            }
+          ],
+          "preRequisites": {
+            "featureFlags": [
+              {
+                "configKey": "AMP_enable-gcm",
+                "value": false
+              },
+              {
+                "configKey": "AMP_enable-gcm"
+              }
+            ],
+            "featureFlagsCondition": "or"
+          }
+        },
+        {
+          "type": "tagInput",
+          "label": "Ketch consent purpose IDs",
+          "note": "Input your Ketch consent purpose IDs by pressing 'Enter' after each entry.",
+          "configKey": "ketchConsentPurposes",
+          "tagKey": "purpose",
+          "placeholder": "e.g: marketing",
+          "default": [
+            {
+              "purpose": ""
+            }
+          ],
+          "preRequisites": {
+            "featureFlags": [
+              {
+                "configKey": "AMP_enable-gcm",
+                "value": false
+              },
+              {
+                "configKey": "AMP_enable-gcm"
+              }
+            ],
+            "featureFlagsCondition": "or"
+          }
+        },
         {
           "type": "dynamicCustomForm",
           "configKey": "consentManagement",

--- a/src/configurations/destinations/ga4/db-config.json
+++ b/src/configurations/destinations/ga4/db-config.json
@@ -73,9 +73,8 @@
         "blacklistedEvents",
         "eventFilteringOption",
         "piiPropertiesToIgnore",
-        "oneTrustCookieCategories",
-        "ketchConsentPurposes",
-        "sdkBaseUrl"
+        "sdkBaseUrl",
+        "serverContainerUrl"
       ],
       "web": [
         "debugView",

--- a/src/configurations/destinations/ga4/db-config.json
+++ b/src/configurations/destinations/ga4/db-config.json
@@ -57,7 +57,11 @@
       "cloud": ["cloud"],
       "warehouse": ["cloud"]
     },
-    "hybridModeCloudEventsFilter": { "web": { "messageType": ["track", "group"] } },
+    "hybridModeCloudEventsFilter": {
+      "web": {
+        "messageType": ["track", "group"]
+      }
+    },
     "destConfig": {
       "defaultConfig": [
         "apiSecret",
@@ -71,8 +75,7 @@
         "piiPropertiesToIgnore",
         "oneTrustCookieCategories",
         "ketchConsentPurposes",
-        "sdkBaseUrl",
-        "serverContainerUrl"
+        "sdkBaseUrl"
       ],
       "web": [
         "debugView",
@@ -82,18 +85,72 @@
         "useNativeSDKToSend",
         "extendPageViewParams",
         "overrideClientAndSessionId",
-        "consentManagement"
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
       ],
-      "android": ["useNativeSDK", "connectionMode", "consentManagement"],
-      "ios": ["useNativeSDK", "connectionMode", "consentManagement"],
-      "unity": ["consentManagement", "connectionMode"],
-      "amp": ["consentManagement", "connectionMode"],
-      "cloud": ["consentManagement", "connectionMode"],
-      "reactnative": ["consentManagement", "connectionMode"],
-      "flutter": ["consentManagement", "connectionMode"],
-      "cordova": ["consentManagement", "connectionMode"],
-      "shopify": ["consentManagement", "connectionMode"],
-      "warehouse": ["consentManagement", "connectionMode"]
+      "android": [
+        "useNativeSDK",
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "ios": [
+        "useNativeSDK",
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "unity": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "amp": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "cloud": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "reactnative": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "flutter": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "cordova": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "shopify": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "warehouse": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ]
     },
     "secretKeys": ["apiSecret"]
   },

--- a/src/configurations/destinations/ga4/schema.json
+++ b/src/configurations/destinations/ga4/schema.json
@@ -59,28 +59,302 @@
         }
       },
       "oneTrustCookieCategories": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "oneTrustCookieCategory": {
-              "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+        "type": "object",
+        "properties": {
+          "android": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "ios": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "unity": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "amp": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cloud": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "reactnative": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "flutter": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cordova": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "warehouse": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "shopify": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
       "ketchConsentPurposes": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "purpose": {
-              "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+        "type": "object",
+        "properties": {
+          "android": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "ios": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "unity": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "amp": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cloud": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "reactnative": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "flutter": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cordova": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "warehouse": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "shopify": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
       "consentManagement": {
         "type": "object",
@@ -111,12 +385,19 @@
               "allOf": [
                 {
                   "if": {
-                    "properties": { "provider": { "const": "custom" } },
+                    "properties": {
+                      "provider": {
+                        "const": "custom"
+                      }
+                    },
                     "required": ["provider"]
                   },
                   "then": {
                     "properties": {
-                      "resolutionStrategy": { "type": "string", "enum": ["and", "or"] }
+                      "resolutionStrategy": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      }
                     },
                     "required": ["resolutionStrategy"]
                   }
@@ -150,12 +431,19 @@
               "allOf": [
                 {
                   "if": {
-                    "properties": { "provider": { "const": "custom" } },
+                    "properties": {
+                      "provider": {
+                        "const": "custom"
+                      }
+                    },
                     "required": ["provider"]
                   },
                   "then": {
                     "properties": {
-                      "resolutionStrategy": { "type": "string", "enum": ["and", "or"] }
+                      "resolutionStrategy": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      }
                     },
                     "required": ["resolutionStrategy"]
                   }
@@ -189,12 +477,19 @@
               "allOf": [
                 {
                   "if": {
-                    "properties": { "provider": { "const": "custom" } },
+                    "properties": {
+                      "provider": {
+                        "const": "custom"
+                      }
+                    },
                     "required": ["provider"]
                   },
                   "then": {
                     "properties": {
-                      "resolutionStrategy": { "type": "string", "enum": ["and", "or"] }
+                      "resolutionStrategy": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      }
                     },
                     "required": ["resolutionStrategy"]
                   }
@@ -228,12 +523,19 @@
               "allOf": [
                 {
                   "if": {
-                    "properties": { "provider": { "const": "custom" } },
+                    "properties": {
+                      "provider": {
+                        "const": "custom"
+                      }
+                    },
                     "required": ["provider"]
                   },
                   "then": {
                     "properties": {
-                      "resolutionStrategy": { "type": "string", "enum": ["and", "or"] }
+                      "resolutionStrategy": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      }
                     },
                     "required": ["resolutionStrategy"]
                   }
@@ -267,12 +569,19 @@
               "allOf": [
                 {
                   "if": {
-                    "properties": { "provider": { "const": "custom" } },
+                    "properties": {
+                      "provider": {
+                        "const": "custom"
+                      }
+                    },
                     "required": ["provider"]
                   },
                   "then": {
                     "properties": {
-                      "resolutionStrategy": { "type": "string", "enum": ["and", "or"] }
+                      "resolutionStrategy": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      }
                     },
                     "required": ["resolutionStrategy"]
                   }
@@ -306,12 +615,19 @@
               "allOf": [
                 {
                   "if": {
-                    "properties": { "provider": { "const": "custom" } },
+                    "properties": {
+                      "provider": {
+                        "const": "custom"
+                      }
+                    },
                     "required": ["provider"]
                   },
                   "then": {
                     "properties": {
-                      "resolutionStrategy": { "type": "string", "enum": ["and", "or"] }
+                      "resolutionStrategy": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      }
                     },
                     "required": ["resolutionStrategy"]
                   }
@@ -345,12 +661,19 @@
               "allOf": [
                 {
                   "if": {
-                    "properties": { "provider": { "const": "custom" } },
+                    "properties": {
+                      "provider": {
+                        "const": "custom"
+                      }
+                    },
                     "required": ["provider"]
                   },
                   "then": {
                     "properties": {
-                      "resolutionStrategy": { "type": "string", "enum": ["and", "or"] }
+                      "resolutionStrategy": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      }
                     },
                     "required": ["resolutionStrategy"]
                   }
@@ -384,12 +707,19 @@
               "allOf": [
                 {
                   "if": {
-                    "properties": { "provider": { "const": "custom" } },
+                    "properties": {
+                      "provider": {
+                        "const": "custom"
+                      }
+                    },
                     "required": ["provider"]
                   },
                   "then": {
                     "properties": {
-                      "resolutionStrategy": { "type": "string", "enum": ["and", "or"] }
+                      "resolutionStrategy": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      }
                     },
                     "required": ["resolutionStrategy"]
                   }
@@ -423,12 +753,19 @@
               "allOf": [
                 {
                   "if": {
-                    "properties": { "provider": { "const": "custom" } },
+                    "properties": {
+                      "provider": {
+                        "const": "custom"
+                      }
+                    },
                     "required": ["provider"]
                   },
                   "then": {
                     "properties": {
-                      "resolutionStrategy": { "type": "string", "enum": ["and", "or"] }
+                      "resolutionStrategy": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      }
                     },
                     "required": ["resolutionStrategy"]
                   }
@@ -462,12 +799,19 @@
               "allOf": [
                 {
                   "if": {
-                    "properties": { "provider": { "const": "custom" } },
+                    "properties": {
+                      "provider": {
+                        "const": "custom"
+                      }
+                    },
                     "required": ["provider"]
                   },
                   "then": {
                     "properties": {
-                      "resolutionStrategy": { "type": "string", "enum": ["and", "or"] }
+                      "resolutionStrategy": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      }
                     },
                     "required": ["resolutionStrategy"]
                   }
@@ -501,12 +845,19 @@
               "allOf": [
                 {
                   "if": {
-                    "properties": { "provider": { "const": "custom" } },
+                    "properties": {
+                      "provider": {
+                        "const": "custom"
+                      }
+                    },
                     "required": ["provider"]
                   },
                   "then": {
                     "properties": {
-                      "resolutionStrategy": { "type": "string", "enum": ["and", "or"] }
+                      "resolutionStrategy": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      }
                     },
                     "required": ["resolutionStrategy"]
                   }
@@ -518,43 +869,110 @@
       },
       "capturePageView": {
         "type": "object",
-        "properties": { "web": { "type": "string", "enum": ["rs", "gtag"], "default": "rs" } }
+        "properties": {
+          "web": {
+            "type": "string",
+            "enum": ["rs", "gtag"],
+            "default": "rs"
+          }
+        }
       },
-      "debugView": { "type": "object", "properties": { "web": { "type": "boolean" } } },
-      "extendPageViewParams": { "type": "object", "properties": { "web": { "type": "boolean" } } },
+      "debugView": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        }
+      },
+      "extendPageViewParams": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        }
+      },
       "overrideClientAndSessionId": {
         "type": "object",
-        "properties": { "web": { "type": "boolean" } }
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        }
       },
       "useNativeSDK": {
         "type": "object",
         "properties": {
-          "android": { "type": "boolean" },
-          "ios": { "type": "boolean" },
-          "web": { "type": "boolean" }
+          "android": {
+            "type": "boolean"
+          },
+          "ios": {
+            "type": "boolean"
+          },
+          "web": {
+            "type": "boolean"
+          }
         }
       },
       "connectionMode": {
         "type": "object",
         "properties": {
-          "android": { "type": "string", "enum": ["cloud", "device"] },
-          "web": { "type": "string", "enum": ["cloud", "device", "hybrid"] },
-          "ios": { "type": "string", "enum": ["cloud", "device"] },
-          "unity": { "type": "string", "enum": ["cloud"] },
-          "amp": { "type": "string", "enum": ["cloud"] },
-          "reactnative": { "type": "string", "enum": ["cloud"] },
-          "flutter": { "type": "string", "enum": ["cloud"] },
-          "cordova": { "type": "string", "enum": ["cloud"] },
-          "shopify": { "type": "string", "enum": ["cloud"] },
-          "cloud": { "type": "string", "enum": ["cloud"] },
-          "warehouse": { "type": "string", "enum": ["cloud"] }
+          "android": {
+            "type": "string",
+            "enum": ["cloud", "device"]
+          },
+          "web": {
+            "type": "string",
+            "enum": ["cloud", "device", "hybrid"]
+          },
+          "ios": {
+            "type": "string",
+            "enum": ["cloud", "device"]
+          },
+          "unity": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "amp": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "reactnative": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "flutter": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "cordova": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "shopify": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "cloud": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "warehouse": {
+            "type": "string",
+            "enum": ["cloud"]
+          }
         }
       }
     },
     "allOf": [
       {
         "if": {
-          "properties": { "typesOfClient": { "const": "gtag" } },
+          "properties": {
+            "typesOfClient": {
+              "const": "gtag"
+            }
+          },
           "required": ["typesOfClient"]
         },
         "then": {
@@ -571,7 +989,12 @@
                 "properties": {
                   "connectionMode": {
                     "type": "object",
-                    "properties": { "web": { "type": "string", "enum": ["device"] } }
+                    "properties": {
+                      "web": {
+                        "type": "string",
+                        "enum": ["device"]
+                      }
+                    }
                   }
                 },
                 "required": ["connectionMode"]
@@ -590,7 +1013,11 @@
       },
       {
         "if": {
-          "properties": { "typesOfClient": { "const": "firebase" } },
+          "properties": {
+            "typesOfClient": {
+              "const": "firebase"
+            }
+          },
           "required": ["typesOfClient"]
         },
         "then": {

--- a/src/configurations/destinations/ga4/schema.json
+++ b/src/configurations/destinations/ga4/schema.json
@@ -70,8 +70,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "ios": {
@@ -83,8 +82,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "web": {
@@ -96,8 +94,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "unity": {
@@ -109,8 +106,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "amp": {
@@ -122,8 +118,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cloud": {
@@ -135,8 +130,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "reactnative": {
@@ -148,8 +142,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "flutter": {
@@ -161,8 +154,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cordova": {
@@ -174,8 +166,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "warehouse": {
@@ -187,8 +178,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "shopify": {
@@ -200,12 +190,10 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
-        },
-        "additionalProperties": false
+        }
       },
       "ketchConsentPurposes": {
         "type": "object",
@@ -219,8 +207,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "ios": {
@@ -232,8 +219,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "web": {
@@ -245,8 +231,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "unity": {
@@ -258,8 +243,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "amp": {
@@ -271,8 +255,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cloud": {
@@ -284,8 +267,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "reactnative": {
@@ -297,8 +279,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "flutter": {
@@ -310,8 +291,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cordova": {
@@ -323,8 +303,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "warehouse": {
@@ -336,8 +315,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "shopify": {
@@ -349,12 +327,10 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
-        },
-        "additionalProperties": false
+        }
       },
       "consentManagement": {
         "type": "object",

--- a/src/configurations/destinations/ga4/ui-config.json
+++ b/src/configurations/destinations/ga4/ui-config.json
@@ -198,84 +198,7 @@
             "title": "Consent settings",
             "note": "Configure consent settings for each provider here",
             "icon": "settings",
-            "groups": [
-              {
-                "title": "OneTrust consent settings",
-                "note": [
-                  "Enter your OneTrust consent category IDs if you have them configured. The support for category names is deprecated. We recommend using the category IDs instead of the names as IDs are unique and less likely to change over time, making them a more reliable choice.",
-                  {
-                    "text": "Learn more ",
-                    "link": "https://www.rudderstack.com/docs/sources/event-streams/sdks/consent-manager/onetrust/"
-                  },
-                  "about RudderStack's OneTrust Consent Management feature."
-                ],
-                "fields": [
-                  {
-                    "type": "tagInput",
-                    "label": "Consent categories",
-                    "note": "Input your OneTrust category IDs by pressing 'Enter' after each entry.",
-                    "configKey": "oneTrustCookieCategories",
-                    "tagKey": "oneTrustCookieCategory",
-                    "placeholder": "e.g: C0001",
-                    "default": [
-                      {
-                        "oneTrustCookieCategory": ""
-                      }
-                    ]
-                  }
-                ],
-                "preRequisites": {
-                  "featureFlags": [
-                    {
-                      "configKey": "AMP_enable-gcm",
-                      "value": false
-                    },
-                    {
-                      "configKey": "AMP_enable-gcm"
-                    }
-                  ],
-                  "featureFlagsCondition": "or"
-                }
-              },
-              {
-                "title": "Ketch consent purpose settings",
-                "note": [
-                  "Enter your Ketch purpose Id if you have them configured. ",
-                  {
-                    "text": "Learn more ",
-                    "link": "https://www.rudderstack.com/docs/sources/event-streams/sdks/consent-manager/ketch/"
-                  },
-                  "about RudderStack and Ketch Consent Manager integration."
-                ],
-                "fields": [
-                  {
-                    "type": "tagInput",
-                    "label": "Purpose ID",
-                    "note": "Input your Ketch purpose Id by pressing 'Enter' after each entry",
-                    "configKey": "ketchConsentPurposes",
-                    "tagKey": "purpose",
-                    "placeholder": "e.g: Marketing",
-                    "default": [
-                      {
-                        "purpose": ""
-                      }
-                    ]
-                  }
-                ],
-                "preRequisites": {
-                  "featureFlags": [
-                    {
-                      "configKey": "AMP_enable-gcm",
-                      "value": false
-                    },
-                    {
-                      "configKey": "AMP_enable-gcm"
-                    }
-                  ],
-                  "featureFlagsCondition": "or"
-                }
-              }
-            ]
+            "groups": []
           },
           {
             "title": "Other settings",
@@ -445,6 +368,56 @@
       "title": "Consent settings",
       "note": "not visible in the ui",
       "fields": [
+        {
+          "type": "tagInput",
+          "label": "OneTrust consent category IDs",
+          "note": "Input your OneTrust category IDs by pressing 'Enter' after each entry. The support for category names is deprecated. We recommend using the category IDs instead of the names as IDs are unique and less likely to change over time, making them a more reliable choice.",
+          "configKey": "oneTrustCookieCategories",
+          "tagKey": "oneTrustCookieCategory",
+          "placeholder": "e.g: C0001",
+          "default": [
+            {
+              "oneTrustCookieCategory": ""
+            }
+          ],
+          "preRequisites": {
+            "featureFlags": [
+              {
+                "configKey": "AMP_enable-gcm",
+                "value": false
+              },
+              {
+                "configKey": "AMP_enable-gcm"
+              }
+            ],
+            "featureFlagsCondition": "or"
+          }
+        },
+        {
+          "type": "tagInput",
+          "label": "Ketch consent purpose IDs",
+          "note": "Input your Ketch consent purpose IDs by pressing 'Enter' after each entry.",
+          "configKey": "ketchConsentPurposes",
+          "tagKey": "purpose",
+          "placeholder": "e.g: marketing",
+          "default": [
+            {
+              "purpose": ""
+            }
+          ],
+          "preRequisites": {
+            "featureFlags": [
+              {
+                "configKey": "AMP_enable-gcm",
+                "value": false
+              },
+              {
+                "configKey": "AMP_enable-gcm"
+              }
+            ],
+            "featureFlagsCondition": "or"
+          }
+        },
         {
           "type": "dynamicCustomForm",
           "configKey": "consentManagement",

--- a/src/configurations/destinations/gtm/db-config.json
+++ b/src/configurations/destinations/gtm/db-config.json
@@ -16,19 +16,29 @@
     ],
     "excludeKeys": [],
     "supportedSourceTypes": ["web"],
-    "supportedMessageTypes": { "device": { "web": ["identify", "track", "page"] } },
-    "supportedConnectionModes": { "web": ["device"] },
+    "supportedMessageTypes": {
+      "device": {
+        "web": ["identify", "track", "page"]
+      }
+    },
+    "supportedConnectionModes": {
+      "web": ["device"]
+    },
     "destConfig": {
       "defaultConfig": [
         "containerID",
         "serverUrl",
         "blacklistedEvents",
         "whitelistedEvents",
-        "eventFilteringOption",
+        "eventFilteringOption"
+      ],
+      "web": [
+        "useNativeSDK",
+        "consentManagement",
+        "connectionMode",
         "oneTrustCookieCategories",
         "ketchConsentPurposes"
-      ],
-      "web": ["useNativeSDK", "consentManagement", "connectionMode"]
+      ]
     },
     "secretKeys": []
   }

--- a/src/configurations/destinations/gtm/schema.json
+++ b/src/configurations/destinations/gtm/schema.json
@@ -61,12 +61,10 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
-        },
-        "additionalProperties": false
+        }
       },
       "ketchConsentPurposes": {
         "type": "object",
@@ -80,12 +78,10 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
-        },
-        "additionalProperties": false
+        }
       },
       "consentManagement": {
         "type": "object",

--- a/src/configurations/destinations/gtm/schema.json
+++ b/src/configurations/destinations/gtm/schema.json
@@ -12,7 +12,14 @@
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|(?!.*\\.ngrok\\.io)^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]*|^$"
       },
-      "useNativeSDK": { "type": "object", "properties": { "web": { "type": "boolean" } } },
+      "useNativeSDK": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "boolean"
+          }
+        }
+      },
       "eventFilteringOption": {
         "type": "string",
         "enum": ["disable", "whitelistedEvents", "blacklistedEvents"],
@@ -43,23 +50,42 @@
         }
       },
       "oneTrustCookieCategories": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "oneTrustCookieCategory": {
-              "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
       "ketchConsentPurposes": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": { "purpose": { "type": "string", "pattern": "^(.{0,100})$" } }
-        }
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
       },
       "consentManagement": {
         "type": "object",
@@ -90,12 +116,19 @@
               "allOf": [
                 {
                   "if": {
-                    "properties": { "provider": { "const": "custom" } },
+                    "properties": {
+                      "provider": {
+                        "const": "custom"
+                      }
+                    },
                     "required": ["provider"]
                   },
                   "then": {
                     "properties": {
-                      "resolutionStrategy": { "type": "string", "enum": ["and", "or"] }
+                      "resolutionStrategy": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      }
                     },
                     "required": ["resolutionStrategy"]
                   }
@@ -107,7 +140,12 @@
       },
       "connectionMode": {
         "type": "object",
-        "properties": { "web": { "type": "string", "enum": ["device"] } }
+        "properties": {
+          "web": {
+            "type": "string",
+            "enum": ["device"]
+          }
+        }
       }
     }
   }

--- a/src/configurations/destinations/gtm/ui-config.json
+++ b/src/configurations/destinations/gtm/ui-config.json
@@ -97,7 +97,7 @@
         {
           "type": "dynamicCustomForm",
           "value": "oneTrustCookieCategories",
-          "label": "OneTrust Consent Categories",
+          "label": "OneTrust Consent Category IDs",
           "footerNote": "The support for category names is deprecated. We recommend using the category IDs instead of the names as IDs are unique and less likely to change over time, making them a more reliable choice.",
           "customFields": [
             {
@@ -125,14 +125,14 @@
         {
           "type": "dynamicCustomForm",
           "value": "ketchConsentPurposes",
-          "label": "Ketch Consent Purposes",
+          "label": "Ketch Consent Purpose IDs",
           "customFields": [
             {
               "type": "textInput",
-              "placeholder": "Marketing",
+              "placeholder": "marketing",
               "value": "purpose",
               "label": "Purpose ID",
-              "regex": "^(.{0,100})$",
+              "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
               "required": false
             }
           ],

--- a/src/configurations/destinations/hotjar/db-config.json
+++ b/src/configurations/destinations/hotjar/db-config.json
@@ -10,7 +10,8 @@
       "whitelistedEvents",
       "oneTrustCookieCategories",
       "eventFilteringOption",
-      "consentManagement"
+      "consentManagement",
+      "ketchConsentPurposes"
     ],
     "excludeKeys": [],
     "supportedSourceTypes": ["web"],
@@ -23,14 +24,14 @@
       }
     },
     "destConfig": {
-      "defaultConfig": [
-        "siteID",
-        "blacklistedEvents",
-        "whitelistedEvents",
-        "eventFilteringOption",
-        "oneTrustCookieCategories"
-      ],
-      "web": ["useNativeSDK", "connectionMode", "consentManagement"]
+      "defaultConfig": ["siteID", "blacklistedEvents", "whitelistedEvents", "eventFilteringOption"],
+      "web": [
+        "useNativeSDK",
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ]
     },
     "secretKeys": []
   }

--- a/src/configurations/destinations/hotjar/schema.json
+++ b/src/configurations/destinations/hotjar/schema.json
@@ -57,12 +57,10 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
-        },
-        "additionalProperties": false
+        }
       },
       "consentManagement": {
         "type": "object",
@@ -136,12 +134,10 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
-        },
-        "additionalProperties": false
+        }
       }
     }
   }

--- a/src/configurations/destinations/hotjar/schema.json
+++ b/src/configurations/destinations/hotjar/schema.json
@@ -46,16 +46,23 @@
         }
       },
       "oneTrustCookieCategories": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "oneTrustCookieCategory": {
-              "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
       "consentManagement": {
         "type": "object",
@@ -111,8 +118,30 @@
       "connectionMode": {
         "type": "object",
         "properties": {
-          "web": { "type": "string", "enum": ["device"] }
+          "web": {
+            "type": "string",
+            "enum": ["device"]
+          }
         }
+      },
+      "ketchConsentPurposes": {
+        "type": "object",
+        "properties": {
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
       }
     }
   }

--- a/src/configurations/destinations/hotjar/ui-config.json
+++ b/src/configurations/destinations/hotjar/ui-config.json
@@ -88,7 +88,7 @@
         {
           "type": "dynamicCustomForm",
           "value": "oneTrustCookieCategories",
-          "label": "OneTrust Consent Categories",
+          "label": "OneTrust Consent Category IDs",
           "footerNote": "The support for category names is deprecated. We recommend using the category IDs instead of the names as IDs are unique and less likely to change over time, making them a more reliable choice.",
           "customFields": [
             {
@@ -97,6 +97,33 @@
               "value": "oneTrustCookieCategory",
               "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
               "label": "Category ID",
+              "required": false
+            }
+          ],
+          "preRequisites": {
+            "featureFlags": [
+              {
+                "configKey": "AMP_enable-gcm",
+                "value": false
+              },
+              {
+                "configKey": "AMP_enable-gcm"
+              }
+            ],
+            "featureFlagsCondition": "or"
+          }
+        },
+        {
+          "type": "dynamicCustomForm",
+          "value": "ketchConsentPurposes",
+          "label": "Ketch Consent Purpose IDs",
+          "customFields": [
+            {
+              "type": "textInput",
+              "placeholder": "marketing",
+              "value": "purpose",
+              "label": "Purpose ID",
+              "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
               "required": false
             }
           ],

--- a/src/configurations/destinations/mp/db-config.json
+++ b/src/configurations/destinations/mp/db-config.json
@@ -54,7 +54,9 @@
     ],
     "supportedMessageTypes": {
       "cloud": ["alias", "group", "identify", "page", "screen", "track"],
-      "device": { "web": ["identify", "track", "page", "group", "alias"] }
+      "device": {
+        "web": ["identify", "track", "page", "group", "alias"]
+      }
     },
     "supportedConnectionModes": {
       "web": ["cloud", "device"],
@@ -98,8 +100,6 @@
         "serviceAccountUserName",
         "serviceAccountSecret",
         "projectId",
-        "oneTrustCookieCategories",
-        "ketchConsentPurposes",
         "identityMergeApi",
         "userDeletionApi",
         "gdprApiToken",
@@ -110,17 +110,73 @@
         "useUserDefinedScreenEventName",
         "userDefinedScreenEventTemplate"
       ],
-      "android": ["consentManagement", "connectionMode"],
-      "web": ["useNativeSDK", "consentManagement", "connectionMode"],
-      "ios": ["consentManagement", "connectionMode"],
-      "unity": ["consentManagement", "connectionMode"],
-      "amp": ["consentManagement", "connectionMode"],
-      "cloud": ["consentManagement", "connectionMode"],
-      "reactnative": ["consentManagement", "connectionMode"],
-      "flutter": ["consentManagement", "connectionMode"],
-      "cordova": ["consentManagement", "connectionMode"],
-      "shopify": ["consentManagement", "connectionMode"],
-      "warehouse": ["consentManagement", "connectionMode"]
+      "android": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "web": [
+        "useNativeSDK",
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "ios": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "unity": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "amp": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "cloud": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "reactnative": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "flutter": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "cordova": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "shopify": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "warehouse": [
+        "consentManagement",
+        "connectionMode",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ]
     },
     "secretKeys": ["token", "gdprApiToken", "apiSecret"]
   }

--- a/src/configurations/destinations/mp/schema.json
+++ b/src/configurations/destinations/mp/schema.json
@@ -203,28 +203,302 @@
         }
       },
       "oneTrustCookieCategories": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "oneTrustCookieCategory": {
-              "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+        "type": "object",
+        "properties": {
+          "android": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "ios": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "unity": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "amp": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cloud": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "warehouse": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "reactnative": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "flutter": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cordova": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "shopify": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
       "ketchConsentPurposes": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "purpose": {
-              "type": "string",
-              "pattern": "^(.{0,100})$"
+        "type": "object",
+        "properties": {
+          "android": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "ios": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "unity": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "amp": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cloud": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "warehouse": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "reactnative": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "flutter": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cordova": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "shopify": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
       "consentManagement": {
         "type": "object",
@@ -740,17 +1014,50 @@
       "connectionMode": {
         "type": "object",
         "properties": {
-          "web": { "type": "string", "enum": ["cloud", "device"] },
-          "android": { "type": "string", "enum": ["cloud"] },
-          "ios": { "type": "string", "enum": ["cloud"] },
-          "unity": { "type": "string", "enum": ["cloud"] },
-          "amp": { "type": "string", "enum": ["cloud"] },
-          "reactnative": { "type": "string", "enum": ["cloud"] },
-          "flutter": { "type": "string", "enum": ["cloud"] },
-          "cordova": { "type": "string", "enum": ["cloud"] },
-          "shopify": { "type": "string", "enum": ["cloud"] },
-          "cloud": { "type": "string", "enum": ["cloud"] },
-          "warehouse": { "type": "string", "enum": ["cloud"] }
+          "web": {
+            "type": "string",
+            "enum": ["cloud", "device"]
+          },
+          "android": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "ios": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "unity": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "amp": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "reactnative": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "flutter": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "cordova": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "shopify": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "cloud": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "warehouse": {
+            "type": "string",
+            "enum": ["cloud"]
+          }
         }
       }
     },

--- a/src/configurations/destinations/mp/schema.json
+++ b/src/configurations/destinations/mp/schema.json
@@ -214,8 +214,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "ios": {
@@ -227,8 +226,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "web": {
@@ -240,8 +238,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "unity": {
@@ -253,8 +250,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "amp": {
@@ -266,8 +262,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cloud": {
@@ -279,8 +274,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "warehouse": {
@@ -292,8 +286,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "reactnative": {
@@ -305,8 +298,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "flutter": {
@@ -318,8 +310,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cordova": {
@@ -331,8 +322,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "shopify": {
@@ -344,12 +334,10 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
-        },
-        "additionalProperties": false
+        }
       },
       "ketchConsentPurposes": {
         "type": "object",
@@ -363,8 +351,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "ios": {
@@ -376,8 +363,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "web": {
@@ -389,8 +375,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "unity": {
@@ -402,8 +387,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "amp": {
@@ -415,8 +399,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cloud": {
@@ -428,8 +411,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "warehouse": {
@@ -441,8 +423,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "reactnative": {
@@ -454,8 +435,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "flutter": {
@@ -467,8 +447,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cordova": {
@@ -480,8 +459,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "shopify": {
@@ -493,12 +471,10 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
-        },
-        "additionalProperties": false
+        }
       },
       "consentManagement": {
         "type": "object",

--- a/src/configurations/destinations/mp/ui-config.json
+++ b/src/configurations/destinations/mp/ui-config.json
@@ -451,7 +451,7 @@
         {
           "type": "dynamicCustomForm",
           "value": "oneTrustCookieCategories",
-          "label": "OneTrust Consent Categories",
+          "label": "OneTrust Consent Category IDs",
           "footerNote": "The support for category names is deprecated. We recommend using the category IDs instead of the names as IDs are unique and less likely to change over time, making them a more reliable choice.",
           "customFields": [
             {
@@ -479,14 +479,14 @@
         {
           "type": "dynamicCustomForm",
           "value": "ketchConsentPurposes",
-          "label": "Ketch Consent Purposes",
+          "label": "Ketch Consent Purpose IDs",
           "customFields": [
             {
               "type": "textInput",
-              "placeholder": "Marketing",
+              "placeholder": "marketing",
               "value": "purpose",
               "label": "Purpose ID",
-              "regex": "^(.{0,100})$",
+              "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
               "required": false
             }
           ],

--- a/src/configurations/destinations/postgres/db-config.json
+++ b/src/configurations/destinations/postgres/db-config.json
@@ -72,20 +72,74 @@
         "useRudderStorage",
         "clientKey",
         "clientCert",
-        "serverCA",
-        "oneTrustCookieCategories"
+        "serverCA"
       ],
-      "android": ["connectionMode", "consentManagement"],
-      "ios": ["connectionMode", "consentManagement"],
-      "web": ["connectionMode", "consentManagement"],
-      "unity": ["connectionMode", "consentManagement"],
-      "amp": ["connectionMode", "consentManagement"],
-      "cloud": ["connectionMode", "consentManagement"],
-      "reactnative": ["connectionMode", "consentManagement"],
-      "cloudSource": ["connectionMode", "consentManagement"],
-      "flutter": ["connectionMode", "consentManagement"],
-      "cordova": ["connectionMode", "consentManagement"],
-      "shopify": ["connectionMode", "consentManagement"]
+      "android": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "ios": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "web": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "unity": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "amp": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "cloud": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "reactnative": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "cloudSource": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "flutter": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "cordova": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ],
+      "shopify": [
+        "connectionMode",
+        "consentManagement",
+        "oneTrustCookieCategories",
+        "ketchConsentPurposes"
+      ]
     },
     "secretKeys": [
       "password",

--- a/src/configurations/destinations/postgres/schema.json
+++ b/src/configurations/destinations/postgres/schema.json
@@ -97,8 +97,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "ios": {
@@ -110,8 +109,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "web": {
@@ -123,8 +121,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "unity": {
@@ -136,8 +133,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "amp": {
@@ -149,8 +145,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cloud": {
@@ -162,8 +157,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "reactnative": {
@@ -175,8 +169,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cloudSource": {
@@ -188,8 +181,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "flutter": {
@@ -201,8 +193,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cordova": {
@@ -214,8 +205,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "shopify": {
@@ -227,12 +217,10 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
-        },
-        "additionalProperties": false
+        }
       },
       "consentManagement": {
         "type": "object",
@@ -806,8 +794,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "ios": {
@@ -819,8 +806,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "web": {
@@ -832,8 +818,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "unity": {
@@ -845,8 +830,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "amp": {
@@ -858,8 +842,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cloud": {
@@ -871,8 +854,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "reactnative": {
@@ -884,8 +866,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cloudSource": {
@@ -897,8 +878,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "flutter": {
@@ -910,8 +890,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "cordova": {
@@ -923,8 +902,7 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           },
           "shopify": {
@@ -936,12 +914,10 @@
                   "type": "string",
                   "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           }
-        },
-        "additionalProperties": false
+        }
       }
     },
     "allOf": [

--- a/src/configurations/destinations/postgres/schema.json
+++ b/src/configurations/destinations/postgres/schema.json
@@ -13,44 +13,226 @@
       "useRudderStorage"
     ],
     "properties": {
-      "host": { "type": "string", "pattern": "(^env[.].+)|(?!.*.ngrok.io)^(.{1,100})$" },
-      "database": { "type": "string", "pattern": "(^env[.].+)|^(.{1,100})$" },
-      "user": { "type": "string", "pattern": "(^env[.].+)|^(.{1,100})$" },
-      "password": { "type": "string", "pattern": "(^env[.].+)|.+" },
-      "port": { "type": "string", "pattern": "(^env[.].+)|^(.{1,100})$" },
-      "skipTracksTable": { "type": "boolean", "default": false },
-      "skipUsersTable": { "type": "boolean", "default": false },
-      "namespace": { "type": "string", "pattern": "(^env[.].*)|^((?!pg_|PG_|pG_|Pg_).{0,64})$" },
-      "sslMode": { "type": "string", "pattern": "^(disable|require|verify-ca)$" },
+      "host": {
+        "type": "string",
+        "pattern": "(^env[.].+)|(?!.*.ngrok.io)^(.{1,100})$"
+      },
+      "database": {
+        "type": "string",
+        "pattern": "(^env[.].+)|^(.{1,100})$"
+      },
+      "user": {
+        "type": "string",
+        "pattern": "(^env[.].+)|^(.{1,100})$"
+      },
+      "password": {
+        "type": "string",
+        "pattern": "(^env[.].+)|.+"
+      },
+      "port": {
+        "type": "string",
+        "pattern": "(^env[.].+)|^(.{1,100})$"
+      },
+      "skipTracksTable": {
+        "type": "boolean",
+        "default": false
+      },
+      "skipUsersTable": {
+        "type": "boolean",
+        "default": false
+      },
+      "namespace": {
+        "type": "string",
+        "pattern": "(^env[.].*)|^((?!pg_|PG_|pG_|Pg_).{0,64})$"
+      },
+      "sslMode": {
+        "type": "string",
+        "pattern": "^(disable|require|verify-ca)$"
+      },
       "syncFrequency": {
         "type": "string",
         "pattern": "^(30|60|180|360|720|1440)$",
         "default": "180"
       },
-      "syncStartAt": { "type": "string" },
+      "syncStartAt": {
+        "type": "string"
+      },
       "excludeWindow": {
         "type": "object",
         "required": ["excludeWindowStartTime", "excludeWindowEndTime"],
         "properties": {
-          "excludeWindowStartTime": { "type": "string" },
-          "excludeWindowEndTime": { "type": "string" }
-        }
-      },
-      "jsonPaths": { "type": "string", "pattern": "(^env[.].*)|.*" },
-      "useRudderStorage": { "type": "boolean", "default": false },
-      "preferAppend": { "type": "boolean", "default": true },
-      "bucketProvider": { "type": "string", "pattern": "^(S3|GCS|AZURE_BLOB|MINIO)$" },
-      "oneTrustCookieCategories": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "oneTrustCookieCategory": {
-              "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
-            }
+          "excludeWindowStartTime": {
+            "type": "string"
+          },
+          "excludeWindowEndTime": {
+            "type": "string"
           }
         }
+      },
+      "jsonPaths": {
+        "type": "string",
+        "pattern": "(^env[.].*)|.*"
+      },
+      "useRudderStorage": {
+        "type": "boolean",
+        "default": false
+      },
+      "preferAppend": {
+        "type": "boolean",
+        "default": true
+      },
+      "bucketProvider": {
+        "type": "string",
+        "pattern": "^(S3|GCS|AZURE_BLOB|MINIO)$"
+      },
+      "oneTrustCookieCategories": {
+        "type": "object",
+        "properties": {
+          "android": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "ios": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "unity": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "amp": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cloud": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "reactnative": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cloudSource": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "flutter": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cordova": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "shopify": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneTrustCookieCategory": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
       },
       "consentManagement": {
         "type": "object",
@@ -566,45 +748,256 @@
       "connectionMode": {
         "type": "object",
         "properties": {
-          "android": { "type": "string", "enum": ["cloud"] },
-          "ios": { "type": "string", "enum": ["cloud"] },
-          "web": { "type": "string", "enum": ["cloud"] },
-          "unity": { "type": "string", "enum": ["cloud"] },
-          "amp": { "type": "string", "enum": ["cloud"] },
-          "reactnative": { "type": "string", "enum": ["cloud"] },
-          "flutter": { "type": "string", "enum": ["cloud"] },
-          "cordova": { "type": "string", "enum": ["cloud"] },
-          "shopify": { "type": "string", "enum": ["cloud"] },
-          "cloud": { "type": "string", "enum": ["cloud"] },
-          "cloudSource": { "type": "string", "enum": ["cloud"] }
+          "android": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "ios": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "web": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "unity": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "amp": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "reactnative": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "flutter": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "cordova": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "shopify": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "cloud": {
+            "type": "string",
+            "enum": ["cloud"]
+          },
+          "cloudSource": {
+            "type": "string",
+            "enum": ["cloud"]
+          }
         }
+      },
+      "ketchConsentPurposes": {
+        "type": "object",
+        "properties": {
+          "android": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "ios": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "web": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "unity": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "amp": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cloud": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "reactnative": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cloudSource": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "flutter": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "cordova": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "shopify": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "purpose": {
+                  "type": "string",
+                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
       }
     },
     "allOf": [
       {
-        "if": { "properties": { "useSSH": { "const": true } }, "required": ["useSSH"] },
+        "if": {
+          "properties": {
+            "useSSH": {
+              "const": true
+            }
+          },
+          "required": ["useSSH"]
+        },
         "then": {
           "properties": {
-            "sshHost": { "type": "string", "pattern": "(^env[.].+)|^(.{1,255})$" },
-            "sshPort": { "type": "string", "pattern": "(^env[.].+)|^(.{1,255})$" },
-            "sshUser": { "type": "string", "pattern": "(^env[.].+)|^(.{1,255})$" },
-            "sshPublicKey": { "type": "string", "pattern": "(^env[.].+)|^(.{1,1000})$" }
+            "sshHost": {
+              "type": "string",
+              "pattern": "(^env[.].+)|^(.{1,255})$"
+            },
+            "sshPort": {
+              "type": "string",
+              "pattern": "(^env[.].+)|^(.{1,255})$"
+            },
+            "sshUser": {
+              "type": "string",
+              "pattern": "(^env[.].+)|^(.{1,255})$"
+            },
+            "sshPublicKey": {
+              "type": "string",
+              "pattern": "(^env[.].+)|^(.{1,1000})$"
+            }
           },
           "required": ["sshHost", "sshPort", "sshUser", "sshPublicKey"]
         }
       },
       {
         "if": {
-          "properties": { "useRudderStorage": { "const": false } },
+          "properties": {
+            "useRudderStorage": {
+              "const": false
+            }
+          },
           "required": ["useRudderStorage"]
         },
-        "then": { "required": ["bucketProvider"] }
+        "then": {
+          "required": ["bucketProvider"]
+        }
       },
       {
         "if": {
           "properties": {
-            "bucketProvider": { "const": "S3" },
-            "useRudderStorage": { "const": false }
+            "bucketProvider": {
+              "const": "S3"
+            },
+            "useRudderStorage": {
+              "const": false
+            }
           },
           "required": ["bucketProvider", "useRudderStorage"]
         },
@@ -620,16 +1013,26 @@
             {
               "type": "object",
               "properties": {
-                "accessKeyID": { "type": "string", "pattern": "(^env[.].+)|^(.{0,100})$" },
-                "accessKey": { "type": "string", "pattern": "(^env[.].+)|^(.{0,100})$" }
+                "accessKeyID": {
+                  "type": "string",
+                  "pattern": "(^env[.].+)|^(.{0,100})$"
+                },
+                "accessKey": {
+                  "type": "string",
+                  "pattern": "(^env[.].+)|^(.{0,100})$"
+                }
               },
               "required": ["accessKeyID", "accessKey"]
             },
             {
               "type": "object",
               "properties": {
-                "iamRoleARN": { "type": "string" },
-                "roleBasedAuth": { "const": true }
+                "iamRoleARN": {
+                  "type": "string"
+                },
+                "roleBasedAuth": {
+                  "const": true
+                }
               },
               "required": ["iamRoleARN", "roleBasedAuth"]
             }
@@ -639,8 +1042,12 @@
       {
         "if": {
           "properties": {
-            "bucketProvider": { "const": "GCS" },
-            "useRudderStorage": { "const": false }
+            "bucketProvider": {
+              "const": "GCS"
+            },
+            "useRudderStorage": {
+              "const": false
+            }
           },
           "required": ["bucketProvider", "useRudderStorage"]
         },
@@ -650,7 +1057,10 @@
               "type": "string",
               "pattern": "(^env[.].+)|^((?!goog)(?!.*google.*)(?!^(\\d+(\\.|$)){4}$)(?!.*\\.\\..*)[a-z0-9][a-z0-9-._]{1,61}[a-z0-9])$"
             },
-            "credentials": { "type": "string", "pattern": "(^env[.].+)|.+" }
+            "credentials": {
+              "type": "string",
+              "pattern": "(^env[.].+)|.+"
+            }
           },
           "required": ["bucketName", "credentials"]
         }
@@ -658,8 +1068,12 @@
       {
         "if": {
           "properties": {
-            "bucketProvider": { "const": "AZURE_BLOB" },
-            "useRudderStorage": { "const": false }
+            "bucketProvider": {
+              "const": "AZURE_BLOB"
+            },
+            "useRudderStorage": {
+              "const": false
+            }
           },
           "required": ["bucketProvider", "useRudderStorage"]
         },
@@ -669,20 +1083,31 @@
               "type": "string",
               "pattern": "(^env[.].+)|^(?=.{3,63}$)[a-z0-9]+(-[a-z0-9]+)*$"
             },
-            "accountName": { "type": "string", "pattern": "(^env[.].+)|^(.{1,100})$" }
+            "accountName": {
+              "type": "string",
+              "pattern": "(^env[.].+)|^(.{1,100})$"
+            }
           },
           "required": ["containerName", "accountName"],
           "anyOf": [
             {
               "properties": {
-                "accountKey": { "type": "string", "pattern": "(^env[.].+)|^(.{1,100})$" }
+                "accountKey": {
+                  "type": "string",
+                  "pattern": "(^env[.].+)|^(.{1,100})$"
+                }
               },
               "required": ["accountKey"]
             },
             {
               "properties": {
-                "sasToken": { "type": "string", "pattern": "(^env[.].+)|^(.+)$" },
-                "useSASTokens": { "const": true }
+                "sasToken": {
+                  "type": "string",
+                  "pattern": "(^env[.].+)|^(.+)$"
+                },
+                "useSASTokens": {
+                  "const": true
+                }
               },
               "required": ["useSASTokens", "sasToken"]
             }
@@ -692,8 +1117,12 @@
       {
         "if": {
           "properties": {
-            "bucketProvider": { "const": "MINIO" },
-            "useRudderStorage": { "const": false }
+            "bucketProvider": {
+              "const": "MINIO"
+            },
+            "useRudderStorage": {
+              "const": false
+            }
           },
           "required": ["bucketProvider", "useRudderStorage"]
         },
@@ -703,19 +1132,34 @@
               "type": "string",
               "pattern": "(^env[.].+)|^((?!^(\\d+(\\.|$)){4}$)[a-z0-9][a-z0-9-.]{1,61}[a-z0-9])$"
             },
-            "accessKeyID": { "type": "string", "pattern": "(^env[.].+)|^(.{1,100})$" },
+            "accessKeyID": {
+              "type": "string",
+              "pattern": "(^env[.].+)|^(.{1,100})$"
+            },
             "endPoint": {
               "type": "string",
               "pattern": "(^env[.].+)|^(?!.*\\.ngrok\\.io)(.{1,100})$"
             },
-            "secretAccessKey": { "type": "string", "pattern": "(^env[.].+)|^(.{1,100})$" },
-            "useSSL": { "type": "boolean" }
+            "secretAccessKey": {
+              "type": "string",
+              "pattern": "(^env[.].+)|^(.{1,100})$"
+            },
+            "useSSL": {
+              "type": "boolean"
+            }
           },
           "required": ["bucketName", "endPoint", "accessKeyID", "secretAccessKey", "useSSL"]
         }
       },
       {
-        "if": { "properties": { "sslMode": { "const": "verify-ca" } }, "required": ["sslMode"] },
+        "if": {
+          "properties": {
+            "sslMode": {
+              "const": "verify-ca"
+            }
+          },
+          "required": ["sslMode"]
+        },
         "then": {
           "properties": {
             "clientKey": {

--- a/src/configurations/destinations/postgres/ui-config.json
+++ b/src/configurations/destinations/postgres/ui-config.json
@@ -622,7 +622,7 @@
         {
           "type": "dynamicCustomForm",
           "value": "oneTrustCookieCategories",
-          "label": "OneTrust Consent Categories",
+          "label": "OneTrust Consent Category IDs",
           "footerNote": "The support for category names is deprecated. We recommend using the category IDs instead of the names as IDs are unique and less likely to change over time, making them a more reliable choice.",
           "customFields": [
             {
@@ -631,6 +631,33 @@
               "value": "oneTrustCookieCategory",
               "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
               "label": "Category ID",
+              "required": false
+            }
+          ],
+          "preRequisites": {
+            "featureFlags": [
+              {
+                "configKey": "AMP_enable-gcm",
+                "value": false
+              },
+              {
+                "configKey": "AMP_enable-gcm"
+              }
+            ],
+            "featureFlagsCondition": "or"
+          }
+        },
+        {
+          "type": "dynamicCustomForm",
+          "value": "ketchConsentPurposes",
+          "label": "Ketch Consent Purpose IDs",
+          "customFields": [
+            {
+              "type": "textInput",
+              "placeholder": "marketing",
+              "value": "purpose",
+              "label": "Purpose ID",
+              "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
               "required": false
             }
           ],

--- a/test/consentManagementFieldsIntegrity.test.ts
+++ b/test/consentManagementFieldsIntegrity.test.ts
@@ -1,0 +1,113 @@
+/*
+THIS IS A TEMPORARY TEST FILE TO VALIDATE THE INTEGRITY OF THE CONSENT MANAGEMENT FIELDS
+IN THE DESTINATIONS' CONFIGURATION FILES
+*/
+
+import fs from 'fs';
+import path from 'path';
+
+const getJSONDataFromFile = (filePath: string) => {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch (e) {
+    console.error(e);
+    console.error(`Unable to load file: "${filePath}"`);
+    return null;
+  }
+};
+
+const deepSearch = (obj: any, value: string, count = 0) => {
+  // eslint-disable-next-line no-restricted-syntax, guard-for-in
+  for (const k in obj) {
+    if (typeof obj[k] === 'object') {
+      // eslint-disable-next-line no-param-reassign
+      count = deepSearch(obj[k], value, count);
+    } else if (obj[k] === value) {
+      // eslint-disable-next-line no-param-reassign
+      count += 1;
+    }
+  }
+  return count;
+};
+
+// These are names of the directories under src/configuration/destinations
+const DESTINATIONS_CONSIDERED = ['am', 'postgres', 'ga4', 'gtm', 'mp', 'hotjar'];
+
+describe('Consent Management Fields Integrity tests', () => {
+  // Read db-config.json, ui-config.json, and schema.json files in each of the directories
+  // under src/configuration/destinations
+  // and ensure the fields oneTrustCookieCategories and ketchConsentPurposes are present
+
+  const destDir = path.resolve('src/configurations/destinations');
+  // const dests = fs
+  //   .readdirSync(destDir)
+  //   .filter((f) => fs.statSync(path.join(destDir, f)).isDirectory());
+  DESTINATIONS_CONSIDERED.forEach((destName) => {
+    // Validate db-config.json
+    const dbConfigFilePath = path.resolve(`${destDir}/${destName}/db-config.json`);
+    const dbConfig = getJSONDataFromFile(dbConfigFilePath);
+    const { destConfig, supportedSourceTypes } = dbConfig.config;
+
+    it(`should have oneTrustCookieCategories and ketchConsentPurposes defined per source type instead of the defaultConfig in ${destName}`, () => {
+      const { defaultConfig } = destConfig;
+
+      expect(
+        defaultConfig.includes('oneTrustCookieCategories') ||
+          defaultConfig.includes('ketchConsentPurposes'),
+      ).toBe(false);
+
+      let fail = false;
+      supportedSourceTypes.forEach((srcType: string) => {
+        if (
+          !(
+            destConfig[srcType].includes('oneTrustCookieCategories') &&
+            destConfig[srcType].includes('ketchConsentPurposes')
+          )
+        ) {
+          fail = true;
+        }
+      });
+
+      expect(fail).toBe(false);
+
+      // Remove defaultConfig from the list of source types
+      const destConfigSrcTypes = Object.keys(destConfig);
+      destConfigSrcTypes.splice(destConfigSrcTypes.indexOf('defaultConfig'), 1);
+      expect(destConfigSrcTypes.sort()).toEqual(supportedSourceTypes.sort());
+    });
+
+    // Validate schema.json
+    const schemaFilePath = path.resolve(`${destDir}/${destName}/schema.json`);
+    const schema = getJSONDataFromFile(schemaFilePath);
+
+    it(`should have oneTrustCookieCategories and ketchConsentPurposes properly defined in schema.json in ${destName}`, () => {
+      expect(schema.configSchema.properties.oneTrustCookieCategories).toBeDefined();
+      expect(schema.configSchema.properties.ketchConsentPurposes).toBeDefined();
+
+      expect(schema.configSchema.properties.oneTrustCookieCategories.type).toBe('object');
+      expect(schema.configSchema.properties.ketchConsentPurposes.type).toBe('object');
+
+      expect(schema.configSchema.properties.oneTrustCookieCategories.properties).toBeDefined();
+      expect(schema.configSchema.properties.ketchConsentPurposes.properties).toBeDefined();
+
+      expect(
+        Object.keys(schema.configSchema.properties.oneTrustCookieCategories.properties).sort(),
+      ).toEqual(supportedSourceTypes.sort());
+      expect(
+        Object.keys(schema.configSchema.properties.ketchConsentPurposes.properties).sort(),
+      ).toEqual(supportedSourceTypes.sort());
+    });
+
+    // Validate ui-config.json
+    const uiConfigFilePath = path.resolve(`${destDir}/${destName}/ui-config.json`);
+    const uiConfig = getJSONDataFromFile(uiConfigFilePath);
+
+    it(`should have oneTrustCookieCategories and ketchConsentPurposes properly defined in ui-config.json in ${destName}`, () => {
+      const oneTrustUIElementCount = deepSearch(uiConfig, 'oneTrustCookieCategories');
+      expect(oneTrustUIElementCount).toEqual(1);
+
+      const ketchUIElementCount = deepSearch(uiConfig, 'ketchConsentPurposes');
+      expect(ketchUIElementCount).toEqual(1);
+    });
+  });
+});

--- a/test/data/validation/destinations/am.json
+++ b/test/data/validation/destinations/am.json
@@ -1103,18 +1103,7 @@
         }
       ],
       "oneTrustCookieCategories": {
-        "someunsupportedsourcetype": [
-          {
-            "oneTrustCookieCategory": "C0001"
-          },
-          {
-            "oneTrustCookieCategory": "C0002"
-          }
-        ],
         "android": [
-          {
-            "someunsupportedkey": "C0001"
-          },
           {
             "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
           },
@@ -1143,18 +1132,7 @@
         ]
       },
       "ketchConsentPurposes": {
-        "someunsupportedsourcetype": [
-          {
-            "purpose": "P1"
-          },
-          {
-            "purpose": "P2"
-          }
-        ],
         "android": [
-          {
-            "someunsupportedkey": "P1"
-          },
           {
             "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
           },
@@ -1185,15 +1163,11 @@
     },
     "result": false,
     "err": [
-      "oneTrustCookieCategories must NOT have additional properties",
-      "oneTrustCookieCategories.android.0 must NOT have additional properties",
-      "oneTrustCookieCategories.android.1.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "oneTrustCookieCategories.android.0.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
       "oneTrustCookieCategories.ios.0.oneTrustCookieCategory must be string",
       "oneTrustCookieCategories.web must be array",
       "oneTrustCookieCategories.unity.0 must be object",
-      "ketchConsentPurposes must NOT have additional properties",
-      "ketchConsentPurposes.android.0 must NOT have additional properties",
-      "ketchConsentPurposes.android.1.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "ketchConsentPurposes.android.0.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
       "ketchConsentPurposes.ios.0.purpose must be string",
       "ketchConsentPurposes.web must be array",
       "ketchConsentPurposes.unity.0 must be object"

--- a/test/data/validation/destinations/am.json
+++ b/test/data/validation/destinations/am.json
@@ -68,11 +68,6 @@
         {
           "eventName": "AM allowed customer check"
         }
-      ],
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
       ]
     },
     "result": true
@@ -532,99 +527,10 @@
         {
           "eventName": "AM allowed customer check"
         }
-      ],
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
       ]
     },
     "result": false,
     "err": ["connectionMode.web must be equal to one of the allowed values"]
-  },
-  {
-    "config": {
-      "apiKey": "8559811e41334c6dXXXXX4b5f6s7gb70",
-      "proxyServerUrl": {
-        "web": "https://abc.example.com"
-      },
-      "apiSecret": "a41d5bc768831f083eXXXXwecfgf7398",
-      "groupTypeTrait": "company_id",
-      "groupValueTrait": "company_name",
-      "trackAllPages": false,
-      "trackCategorizedPages": true,
-      "trackNamedPages": true,
-      "trackProductsOnce": false,
-      "trackRevenuePerProduct": false,
-      "versionName": "1.11.3",
-      "residencyServer": "standard",
-      "connectionMode": {
-        "web": "device",
-        "android": "device",
-        "ios": "cloud",
-        "reactnative": "cloud",
-        "flutter": "device"
-      },
-      "traitsToIncrement": [
-        {
-          "traits": "presentclass"
-        },
-        {
-          "traits": "presentgrade"
-        }
-      ],
-      "traitsToPrepend": [
-        {
-          "traits": "prequelclass"
-        }
-      ],
-      "traitsToSetOnce": [
-        {
-          "traits": "initialclass"
-        }
-      ],
-      "useNativeSDK": {
-        "web": true,
-        "android": true,
-        "ios": false,
-        "reactnative": false,
-        "flutter": true
-      },
-      "preferAnonymousIdForDeviceId": {
-        "web": false
-      },
-      "attribution": {
-        "web": 123
-      },
-      "trackNewCampaigns": {
-        "web": true
-      },
-      "eventUploadPeriodMillis": {
-        "web": "30000"
-      },
-      "eventUploadThreshold": {
-        "web": "30"
-      },
-      "blacklistedEvents": [
-        {
-          "eventName": "AM sample removed"
-        }
-      ],
-      "whitelistedEvents": [
-        {
-          "eventName": "AM allowed customer check"
-        }
-      ],
-      "oneTrustCookieCategories": {
-        "web": [
-          {
-            "oneTrustCookieCategory": "Marketing"
-          }
-        ]
-      }
-    },
-    "result": false,
-    "err": ["oneTrustCookieCategories must be array", "attribution.web must be boolean"]
   },
   {
     "config": {
@@ -734,72 +640,9 @@
         {
           "eventName": "AM allowed customer check"
         }
-      ],
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
       ]
     },
     "result": true
-  },
-  {
-    "config": {
-      "apiKey": "8559811e41334c6dXXXXX4b5f6s7gb70",
-      "apiSecret": "a41d5bc768831f083eXXXXwecfgf7398",
-      "groupTypeTrait": "company_id",
-      "groupValueTrait": "company_name",
-      "trackAllPages": false,
-      "trackCategorizedPages": true,
-      "trackNamedPages": true,
-      "trackProductsOnce": false,
-      "trackRevenuePerProduct": false,
-      "versionName": "1.11.3",
-      "residencyServer": "standard",
-      "connectionMode": {
-        "web": "cloud"
-      },
-      "traitsToIncrement": [],
-      "traitsToPrepend": [],
-      "traitsToSetOnce": [],
-      "enableEnhancedUserOperations": {
-        "web": true
-      },
-      "useNativeSDK": {
-        "web": false
-      },
-      "preferAnonymousIdForDeviceId": {
-        "web": false
-      },
-      "trackNewCampaigns": {
-        "web": true
-      },
-      "eventUploadPeriodMillis": {
-        "web": "30000"
-      },
-      "eventUploadThreshold": {
-        "web": "30"
-      },
-      "attribution": {
-        "web": true
-      },
-      "blacklistedEvents": [
-        {
-          "eventName": "AM sample removed"
-        }
-      ],
-      "whitelistedEvents": [
-        {
-          "eventName": "AM allowed customer check"
-        }
-      ],
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
-      ]
-    },
-    "result": false
   },
   {
     "testTitle": "With valid multiple consent management providers config",
@@ -903,5 +746,457 @@
     },
     "result": false,
     "err": ["consentManagement.android.0.provider must be equal to one of the allowed values"]
+  },
+  {
+    "config": {
+      "apiKey": "8559811e41334c6dXXXXX4b5f6s7gb70",
+      "apiSecret": "a41d5bc768831f083eXXXXwecfgf7398",
+      "groupTypeTrait": "company_id",
+      "groupValueTrait": "company_name",
+      "trackAllPages": false,
+      "trackCategorizedPages": true,
+      "trackNamedPages": true,
+      "trackProductsOnce": false,
+      "trackRevenuePerProduct": false,
+      "versionName": "1.11.3",
+      "residencyServer": "standard",
+      "connectionMode": {
+        "web": "cloud",
+        "android": "device",
+        "ios": "cloud",
+        "reactnative": "cloud",
+        "flutter": "device"
+      },
+      "traitsToIncrement": [
+        {
+          "traits": "presentclass"
+        },
+        {
+          "traits": "presentgrade"
+        }
+      ],
+      "traitsToPrepend": [
+        {
+          "traits": "prequelclass"
+        }
+      ],
+      "traitsToSetOnce": [
+        {
+          "traits": "initialclass"
+        }
+      ],
+      "useNativeSDK": {
+        "web": false,
+        "android": true,
+        "ios": false,
+        "reactnative": false,
+        "flutter": true
+      },
+      "preferAnonymousIdForDeviceId": {
+        "web": false
+      },
+      "trackNewCampaigns": {
+        "web": true
+      },
+      "eventUploadPeriodMillis": {
+        "web": "30000"
+      },
+      "eventUploadThreshold": {
+        "web": "30"
+      },
+      "attribution": {
+        "web": true
+      },
+      "blacklistedEvents": [
+        {
+          "eventName": "AM sample removed"
+        }
+      ],
+      "whitelistedEvents": [
+        {
+          "eventName": "AM allowed customer check"
+        }
+      ],
+      "oneTrustCookieCategories": {
+        "android": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "ios": [
+          {
+            "oneTrustCookieCategory": "C0003"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "web": [
+          {
+            "oneTrustCookieCategory": ""
+          }
+        ],
+        "unity": [],
+        "amp": [
+          {
+            "oneTrustCookieCategory": "env.ENVIRONMENT_VARIABLE"
+          }
+        ],
+        "cloud": [
+          {
+            "oneTrustCookieCategory": "{{ event.properties.prop1 || 'val' }}"
+          }
+        ],
+        "warehouse": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "reactnative": [
+          {
+            "oneTrustCookieCategory": "C0003"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "flutter": [
+          {
+            "oneTrustCookieCategory": ""
+          }
+        ],
+        "cordova": [],
+        "shopify": [
+          {
+            "oneTrustCookieCategory": "env.ENVIRONMENT_VARIABLE"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "android": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "ios": [
+          {
+            "purpose": "P3"
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "web": [
+          {
+            "purpose": ""
+          }
+        ],
+        "unity": [],
+        "amp": [
+          {
+            "purpose": "env.ENVIRONMENT_VARIABLE"
+          }
+        ],
+        "cloud": [
+          {
+            "purpose": "{{ event.properties.prop1 || 'val' }}"
+          }
+        ],
+        "warehouse": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "reactnative": [
+          {
+            "purpose": "P3"
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "flutter": [
+          {
+            "purpose": ""
+          }
+        ],
+        "cordova": [],
+        "shopify": [
+          {
+            "purpose": "env.ENVIRONMENT_VARIABLE"
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "apiKey": "8559811e41334c6dXXXXX4b5f6s7gb70",
+      "apiSecret": "a41d5bc768831f083eXXXXwecfgf7398",
+      "groupTypeTrait": "company_id",
+      "groupValueTrait": "company_name",
+      "trackAllPages": false,
+      "trackCategorizedPages": true,
+      "trackNamedPages": true,
+      "trackProductsOnce": false,
+      "trackRevenuePerProduct": false,
+      "versionName": "1.11.3",
+      "residencyServer": "standard",
+      "connectionMode": {
+        "web": "cloud",
+        "android": "device",
+        "ios": "cloud",
+        "reactnative": "cloud",
+        "flutter": "device"
+      },
+      "traitsToIncrement": [
+        {
+          "traits": "presentclass"
+        },
+        {
+          "traits": "presentgrade"
+        }
+      ],
+      "traitsToPrepend": [
+        {
+          "traits": "prequelclass"
+        }
+      ],
+      "traitsToSetOnce": [
+        {
+          "traits": "initialclass"
+        }
+      ],
+      "useNativeSDK": {
+        "web": false,
+        "android": true,
+        "ios": false,
+        "reactnative": false,
+        "flutter": true
+      },
+      "preferAnonymousIdForDeviceId": {
+        "web": false
+      },
+      "trackNewCampaigns": {
+        "web": true
+      },
+      "eventUploadPeriodMillis": {
+        "web": "30000"
+      },
+      "eventUploadThreshold": {
+        "web": "30"
+      },
+      "attribution": {
+        "web": true
+      },
+      "blacklistedEvents": [
+        {
+          "eventName": "AM sample removed"
+        }
+      ],
+      "whitelistedEvents": [
+        {
+          "eventName": "AM allowed customer check"
+        }
+      ],
+      "oneTrustCookieCategories": [
+        {
+          "oneTrustCookieCategory": "C0001"
+        },
+        {
+          "oneTrustCookieCategory": "C0002"
+        }
+      ],
+      "ketchConsentPurposes": [
+        {
+          "purpose": "P1"
+        },
+        {
+          "purpose": "P2"
+        }
+      ]
+    },
+    "result": false,
+    "err": ["oneTrustCookieCategories must be object", "ketchConsentPurposes must be object"]
+  },
+  {
+    "config": {
+      "apiKey": "8559811e41334c6dXXXXX4b5f6s7gb70",
+      "apiSecret": "a41d5bc768831f083eXXXXwecfgf7398",
+      "groupTypeTrait": "company_id",
+      "groupValueTrait": "company_name",
+      "trackAllPages": false,
+      "trackCategorizedPages": true,
+      "trackNamedPages": true,
+      "trackProductsOnce": false,
+      "trackRevenuePerProduct": false,
+      "versionName": "1.11.3",
+      "residencyServer": "standard",
+      "connectionMode": {
+        "web": "cloud",
+        "android": "device",
+        "ios": "cloud",
+        "reactnative": "cloud",
+        "flutter": "device"
+      },
+      "traitsToIncrement": [
+        {
+          "traits": "presentclass"
+        },
+        {
+          "traits": "presentgrade"
+        }
+      ],
+      "traitsToPrepend": [
+        {
+          "traits": "prequelclass"
+        }
+      ],
+      "traitsToSetOnce": [
+        {
+          "traits": "initialclass"
+        }
+      ],
+      "useNativeSDK": {
+        "web": false,
+        "android": true,
+        "ios": false,
+        "reactnative": false,
+        "flutter": true
+      },
+      "preferAnonymousIdForDeviceId": {
+        "web": false
+      },
+      "trackNewCampaigns": {
+        "web": true
+      },
+      "eventUploadPeriodMillis": {
+        "web": "30000"
+      },
+      "eventUploadThreshold": {
+        "web": "30"
+      },
+      "attribution": {
+        "web": true
+      },
+      "blacklistedEvents": [
+        {
+          "eventName": "AM sample removed"
+        }
+      ],
+      "whitelistedEvents": [
+        {
+          "eventName": "AM allowed customer check"
+        }
+      ],
+      "oneTrustCookieCategories": {
+        "someunsupportedsourcetype": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "android": [
+          {
+            "someunsupportedkey": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "ios": [
+          {
+            "oneTrustCookieCategory": {
+              "not": "a string"
+            }
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "web": {
+          "not": "an array"
+        },
+        "unity": [
+          "not an object",
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "someunsupportedsourcetype": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "android": [
+          {
+            "someunsupportedkey": "P1"
+          },
+          {
+            "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "ios": [
+          {
+            "purpose": {
+              "not": "a string"
+            }
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "web": {
+          "not": "an array"
+        },
+        "unity": [
+          "not an object",
+          {
+            "purpose": "P4"
+          }
+        ]
+      }
+    },
+    "result": false,
+    "err": [
+      "oneTrustCookieCategories must NOT have additional properties",
+      "oneTrustCookieCategories.android.0 must NOT have additional properties",
+      "oneTrustCookieCategories.android.1.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "oneTrustCookieCategories.ios.0.oneTrustCookieCategory must be string",
+      "oneTrustCookieCategories.web must be array",
+      "oneTrustCookieCategories.unity.0 must be object",
+      "ketchConsentPurposes must NOT have additional properties",
+      "ketchConsentPurposes.android.0 must NOT have additional properties",
+      "ketchConsentPurposes.android.1.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "ketchConsentPurposes.ios.0.purpose must be string",
+      "ketchConsentPurposes.web must be array",
+      "ketchConsentPurposes.unity.0 must be object"
+    ]
   }
 ]

--- a/test/data/validation/destinations/ga4.json
+++ b/test/data/validation/destinations/ga4.json
@@ -712,18 +712,7 @@
       },
       "debugMode": false,
       "oneTrustCookieCategories": {
-        "someunsupportedsourcetype": [
-          {
-            "oneTrustCookieCategory": "C0001"
-          },
-          {
-            "oneTrustCookieCategory": "C0002"
-          }
-        ],
         "android": [
-          {
-            "someunsupportedkey": "C0001"
-          },
           {
             "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
           },
@@ -752,18 +741,7 @@
         ]
       },
       "ketchConsentPurposes": {
-        "someunsupportedsourcetype": [
-          {
-            "purpose": "P1"
-          },
-          {
-            "purpose": "P2"
-          }
-        ],
         "android": [
-          {
-            "someunsupportedkey": "P1"
-          },
           {
             "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
           },
@@ -794,15 +772,11 @@
     },
     "result": false,
     "err": [
-      "oneTrustCookieCategories must NOT have additional properties",
-      "oneTrustCookieCategories.android.0 must NOT have additional properties",
-      "oneTrustCookieCategories.android.1.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "oneTrustCookieCategories.android.0.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
       "oneTrustCookieCategories.ios.0.oneTrustCookieCategory must be string",
       "oneTrustCookieCategories.web must be array",
       "oneTrustCookieCategories.unity.0 must be object",
-      "ketchConsentPurposes must NOT have additional properties",
-      "ketchConsentPurposes.android.0 must NOT have additional properties",
-      "ketchConsentPurposes.android.1.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "ketchConsentPurposes.android.0.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
       "ketchConsentPurposes.ios.0.purpose must be string",
       "ketchConsentPurposes.web must be array",
       "ketchConsentPurposes.unity.0 must be object"

--- a/test/data/validation/destinations/ga4.json
+++ b/test/data/validation/destinations/ga4.json
@@ -31,12 +31,7 @@
       "useNativeSDK": {
         "web": false
       },
-      "debugMode": false,
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
-      ]
+      "debugMode": false
     },
     "result": true
   },
@@ -78,12 +73,7 @@
       "useNativeSDK": {
         "web": true
       },
-      "debugMode": false,
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
-      ]
+      "debugMode": false
     },
     "result": false,
     "err": [
@@ -128,12 +118,7 @@
       "useNativeSDK": {
         "web": false
       },
-      "debugMode": false,
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
-      ]
+      "debugMode": false
     },
     "result": true
   },
@@ -174,12 +159,7 @@
       "useNativeSDK": {
         "web": true
       },
-      "debugMode": true,
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
-      ]
+      "debugMode": true
     },
     "result": true
   },
@@ -220,12 +200,7 @@
       "useNativeSDK": {
         "web": false
       },
-      "debugMode": false,
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
-      ]
+      "debugMode": false
     },
     "result": true
   },
@@ -268,12 +243,7 @@
         "android": false,
         "web": false
       },
-      "debugMode": false,
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
-      ]
+      "debugMode": false
     },
     "result": true
   },
@@ -317,12 +287,7 @@
       "useNativeSDK": {
         "web": true
       },
-      "debugMode": false,
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
-      ]
+      "debugMode": false
     },
     "result": true
   },
@@ -431,43 +396,6 @@
       "typesOfClient": "gtag",
       "measurementId": "G-adfg",
       "firebaseAppId": "",
-      "whitelistedEvents": [{ "eventName": "" }],
-      "blacklistedEvents": [{ "eventName": "" }],
-      "eventFilteringOption": "disable",
-      "piiPropertiesToIgnore": [{ "piiProperty": "" }],
-      "oneTrustCookieCategories": [{ "oneTrustCookieCategory": "" }],
-      "ketchConsentPurposes": [{ "purpose": "" }],
-      "consentManagement": {
-        "web": [
-          {
-            "provider": "custom",
-            "resolutionStrategy": "or",
-            "consents": [{ "consent": "vjvh" }, { "consent": "hkvhkv" }, { "consent": "jhvjh" }]
-          },
-          {
-            "provider": "oneTrust",
-            "resolutionStrategy": "and",
-            "consents": [{ "consent": "mvhvjv" }, { "consent": "jvjvjv" }]
-          }
-        ]
-      },
-      "debugView": { "web": true },
-      "useNativeSDK": { "web": false },
-      "connectionMode": { "web": "cloud" },
-      "capturePageView": { "web": "rs" },
-      "useNativeSDKToSend": { "web": false },
-      "extendPageViewParams": { "web": false },
-      "overrideClientAndSessionId": { "web": true }
-    },
-    "result": true
-  },
-  {
-    "config": {
-      "debugMode": false,
-      "typesOfClient": "gtag",
-      "measurementId": "G-23132",
-      "apiSecret": "QyWIGHjXXXX2L4ePAPiXCA",
-      "firebaseAppId": "",
       "whitelistedEvents": [
         {
           "eventName": ""
@@ -484,28 +412,45 @@
           "piiProperty": ""
         }
       ],
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": ""
-        }
-      ],
-      "ketchConsentPurposes": [
-        {
-          "purpose": ""
-        }
-      ],
-      "sdkBaseUrl": "https://ddim5kcy73icz.cloudfront.net/GA4_Test",
-      "serverContainerUrl": "https://webhook.site/681e1145-6f87-4878-b13a-d51e35919923",
+      "consentManagement": {
+        "web": [
+          {
+            "provider": "custom",
+            "resolutionStrategy": "or",
+            "consents": [
+              {
+                "consent": "vjvh"
+              },
+              {
+                "consent": "hkvhkv"
+              },
+              {
+                "consent": "jhvjh"
+              }
+            ]
+          },
+          {
+            "provider": "oneTrust",
+            "resolutionStrategy": "and",
+            "consents": [
+              {
+                "consent": "mvhvjv"
+              },
+              {
+                "consent": "jvjvjv"
+              }
+            ]
+          }
+        ]
+      },
       "debugView": {
         "web": true
       },
       "useNativeSDK": {
-        "web": true,
-        "android": false
+        "web": false
       },
       "connectionMode": {
-        "web": "hybrid",
-        "android": "cloud"
+        "web": "cloud"
       },
       "capturePageView": {
         "web": "rs"
@@ -517,10 +462,350 @@
         "web": false
       },
       "overrideClientAndSessionId": {
-        "web": false
-      },
-      "consentManagement": {}
+        "web": true
+      }
     },
     "result": true
+  },
+  {
+    "config": {
+      "apiSecret": "QyWIGHjXXXX2L4ePAPiXCA",
+      "typesOfClient": "gtag",
+      "measurementId": "G-T40XXXKET4",
+      "firebaseAppId": "",
+      "capturePageView": {
+        "web": "rs"
+      },
+      "extendPageViewParams": {
+        "web": true
+      },
+      "debugView": {
+        "web": false
+      },
+      "connectionMode": {
+        "web": "cloud"
+      },
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": false
+      },
+      "debugMode": false,
+      "oneTrustCookieCategories": {
+        "android": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "ios": [
+          {
+            "oneTrustCookieCategory": "C0003"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "web": [
+          {
+            "oneTrustCookieCategory": ""
+          }
+        ],
+        "unity": [],
+        "amp": [
+          {
+            "oneTrustCookieCategory": "env.ENVIRONMENT_VARIABLE"
+          }
+        ],
+        "cloud": [
+          {
+            "oneTrustCookieCategory": "{{ event.properties.prop1 || 'val' }}"
+          }
+        ],
+        "reactnative": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "flutter": [
+          {
+            "oneTrustCookieCategory": "C0003"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "cordova": [
+          {
+            "oneTrustCookieCategory": ""
+          }
+        ],
+        "warehouse": [],
+        "shopify": [
+          {
+            "oneTrustCookieCategory": "env.ENVIRONMENT_VARIABLE"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "android": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "ios": [
+          {
+            "purpose": "P3"
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "web": [
+          {
+            "purpose": ""
+          }
+        ],
+        "unity": [],
+        "amp": [
+          {
+            "purpose": "env.ENVIRONMENT_VARIABLE"
+          }
+        ],
+        "cloud": [
+          {
+            "purpose": "{{ event.properties.prop1 || 'val' }}"
+          }
+        ],
+        "reactnative": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "flutter": [
+          {
+            "purpose": "P3"
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "cordova": [
+          {
+            "purpose": ""
+          }
+        ],
+        "warehouse": [],
+        "shopify": [
+          {
+            "purpose": "env.ENVIRONMENT_VARIABLE"
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "apiSecret": "QyWIGHjXXXX2L4ePAPiXCA",
+      "typesOfClient": "gtag",
+      "measurementId": "G-T40XXXKET4",
+      "firebaseAppId": "",
+      "capturePageView": {
+        "web": "rs"
+      },
+      "extendPageViewParams": {
+        "web": true
+      },
+      "debugView": {
+        "web": false
+      },
+      "connectionMode": {
+        "web": "cloud"
+      },
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": false
+      },
+      "debugMode": false,
+      "oneTrustCookieCategories": [
+        {
+          "oneTrustCookieCategory": "C0001"
+        },
+        {
+          "oneTrustCookieCategory": "C0002"
+        }
+      ],
+      "ketchConsentPurposes": [
+        {
+          "purpose": "P1"
+        },
+        {
+          "purpose": "P2"
+        }
+      ]
+    },
+    "result": false,
+    "err": ["oneTrustCookieCategories must be object", "ketchConsentPurposes must be object"]
+  },
+  {
+    "config": {
+      "apiSecret": "QyWIGHjXXXX2L4ePAPiXCA",
+      "typesOfClient": "gtag",
+      "measurementId": "G-T40XXXKET4",
+      "firebaseAppId": "",
+      "capturePageView": {
+        "web": "rs"
+      },
+      "extendPageViewParams": {
+        "web": true
+      },
+      "debugView": {
+        "web": false
+      },
+      "connectionMode": {
+        "web": "cloud"
+      },
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": false
+      },
+      "debugMode": false,
+      "oneTrustCookieCategories": {
+        "someunsupportedsourcetype": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "android": [
+          {
+            "someunsupportedkey": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "ios": [
+          {
+            "oneTrustCookieCategory": {
+              "not": "a string"
+            }
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "web": {
+          "not": "an array"
+        },
+        "unity": [
+          "not an object",
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "someunsupportedsourcetype": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "android": [
+          {
+            "someunsupportedkey": "P1"
+          },
+          {
+            "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "ios": [
+          {
+            "purpose": {
+              "not": "a string"
+            }
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "web": {
+          "not": "an array"
+        },
+        "unity": [
+          "not an object",
+          {
+            "purpose": "P4"
+          }
+        ]
+      }
+    },
+    "result": false,
+    "err": [
+      "oneTrustCookieCategories must NOT have additional properties",
+      "oneTrustCookieCategories.android.0 must NOT have additional properties",
+      "oneTrustCookieCategories.android.1.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "oneTrustCookieCategories.ios.0.oneTrustCookieCategory must be string",
+      "oneTrustCookieCategories.web must be array",
+      "oneTrustCookieCategories.unity.0 must be object",
+      "ketchConsentPurposes must NOT have additional properties",
+      "ketchConsentPurposes.android.0 must NOT have additional properties",
+      "ketchConsentPurposes.android.1.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "ketchConsentPurposes.ios.0.purpose must be string",
+      "ketchConsentPurposes.web must be array",
+      "ketchConsentPurposes.unity.0 must be object"
+    ]
   }
 ]

--- a/test/data/validation/destinations/ga4.json
+++ b/test/data/validation/destinations/ga4.json
@@ -469,6 +469,58 @@
   },
   {
     "config": {
+      "debugMode": false,
+      "typesOfClient": "gtag",
+      "measurementId": "G-23132",
+      "apiSecret": "QyWIGHjXXXX2L4ePAPiXCA",
+      "firebaseAppId": "",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "eventFilteringOption": "disable",
+      "piiPropertiesToIgnore": [
+        {
+          "piiProperty": ""
+        }
+      ],
+      "sdkBaseUrl": "https://ddim5kcy73icz.cloudfront.net/GA4_Test",
+      "serverContainerUrl": "https://webhook.site/681e1145-6f87-4878-b13a-d51e35919923",
+      "debugView": {
+        "web": true
+      },
+      "useNativeSDK": {
+        "web": true,
+        "android": false
+      },
+      "connectionMode": {
+        "web": "hybrid",
+        "android": "cloud"
+      },
+      "capturePageView": {
+        "web": "rs"
+      },
+      "useNativeSDKToSend": {
+        "web": false
+      },
+      "extendPageViewParams": {
+        "web": false
+      },
+      "overrideClientAndSessionId": {
+        "web": false
+      },
+      "consentManagement": {}
+    },
+    "result": true
+  },
+  {
+    "config": {
       "apiSecret": "QyWIGHjXXXX2L4ePAPiXCA",
       "typesOfClient": "gtag",
       "measurementId": "G-T40XXXKET4",

--- a/test/data/validation/destinations/gtm.json
+++ b/test/data/validation/destinations/gtm.json
@@ -16,8 +16,7 @@
       ],
       "useNativeSDK": {
         "web": true
-      },
-      "oneTrustCookieCategories": []
+      }
     },
     "result": true
   },
@@ -37,8 +36,7 @@
       ],
       "useNativeSDK": {
         "web": true
-      },
-      "oneTrustCookieCategories": []
+      }
     },
     "result": false,
     "err": [" must have required property 'containerID'"]
@@ -60,8 +58,7 @@
       ],
       "useNativeSDK": {
         "web": true
-      },
-      "oneTrustCookieCategories": []
+      }
     },
     "result": false,
     "err": [
@@ -85,8 +82,7 @@
       ],
       "useNativeSDK": {
         "web": true
-      },
-      "oneTrustCookieCategories": []
+      }
     },
     "result": true
   },
@@ -107,8 +103,7 @@
       ],
       "useNativeSDK": {
         "web": true
-      },
-      "oneTrustCookieCategories": []
+      }
     },
     "result": false,
     "err": [
@@ -212,5 +207,450 @@
     },
     "result": false,
     "err": ["consentManagement.web.0.provider must be equal to one of the allowed values"]
+  },
+  {
+    "config": {
+      "containerID": "GTM-XXXX",
+      "serverUrl": "https://gtm.rudder.com",
+      "eventFilteringOption": "whitelistedEvents",
+      "whitelistedEvents": [
+        {
+          "eventName": "registration"
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "containerID": "GTM-XXXX",
+      "serverUrl": "https://gtm.rudder.com",
+      "eventFilteringOption": "whitelistedEvents",
+      "whitelistedEvents": [
+        {
+          "eventName": "registration"
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          {
+            "oneTrustCookieCategory": "C0003"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          {
+            "purpose": "P3"
+          },
+          {
+            "purpose": "P4"
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "containerID": "GTM-XXXX",
+      "serverUrl": "https://gtm.rudder.com",
+      "eventFilteringOption": "whitelistedEvents",
+      "whitelistedEvents": [
+        {
+          "eventName": "registration"
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          {
+            "oneTrustCookieCategory": ""
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          {
+            "purpose": ""
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "containerID": "GTM-XXXX",
+      "serverUrl": "https://gtm.rudder.com",
+      "eventFilteringOption": "whitelistedEvents",
+      "whitelistedEvents": [
+        {
+          "eventName": "registration"
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": []
+      },
+      "ketchConsentPurposes": {
+        "web": []
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "containerID": "GTM-XXXX",
+      "serverUrl": "https://gtm.rudder.com",
+      "eventFilteringOption": "whitelistedEvents",
+      "whitelistedEvents": [
+        {
+          "eventName": "registration"
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          {
+            "oneTrustCookieCategory": "env.ENVIRONMENT_VARIABLE"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          {
+            "purpose": "env.ENVIRONMENT_VARIABLE"
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "containerID": "GTM-XXXX",
+      "serverUrl": "https://gtm.rudder.com",
+      "eventFilteringOption": "whitelistedEvents",
+      "whitelistedEvents": [
+        {
+          "eventName": "registration"
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          {
+            "oneTrustCookieCategory": "{{ event.properties.prop1 || 'val' }}"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          {
+            "purpose": "{{ event.properties.prop1 || 'val' }}"
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "containerID": "GTM-XXXX",
+      "serverUrl": "https://gtm.rudder.com",
+      "eventFilteringOption": "whitelistedEvents",
+      "whitelistedEvents": [
+        {
+          "eventName": "registration"
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": [
+        {
+          "oneTrustCookieCategory": "C0001"
+        },
+        {
+          "oneTrustCookieCategory": "C0002"
+        }
+      ],
+      "ketchConsentPurposes": [
+        {
+          "purpose": "P1"
+        },
+        {
+          "purpose": "P2"
+        }
+      ]
+    },
+    "result": false,
+    "err": ["oneTrustCookieCategories must be object", "ketchConsentPurposes must be object"]
+  },
+  {
+    "config": {
+      "containerID": "GTM-XXXX",
+      "serverUrl": "https://gtm.rudder.com",
+      "eventFilteringOption": "whitelistedEvents",
+      "whitelistedEvents": [
+        {
+          "eventName": "registration"
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "someunsupportedsourcetype": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "web": [
+          {
+            "someunsupportedkey": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "someunsupportedsourcetype": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "web": [
+          {
+            "someunsupportedkey": "P1"
+          },
+          {
+            "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "purpose": "P4"
+          }
+        ]
+      }
+    },
+    "result": false,
+    "err": [
+      "oneTrustCookieCategories must NOT have additional properties",
+      "oneTrustCookieCategories.web.0 must NOT have additional properties",
+      "oneTrustCookieCategories.web.1.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "ketchConsentPurposes must NOT have additional properties",
+      "ketchConsentPurposes.web.0 must NOT have additional properties",
+      "ketchConsentPurposes.web.1.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\""
+    ]
+  },
+  {
+    "config": {
+      "containerID": "GTM-XXXX",
+      "serverUrl": "https://gtm.rudder.com",
+      "eventFilteringOption": "whitelistedEvents",
+      "whitelistedEvents": [
+        {
+          "eventName": "registration"
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          {
+            "oneTrustCookieCategory": {
+              "not": "a string"
+            }
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          {
+            "purpose": {
+              "not": "a string"
+            }
+          },
+          {
+            "purpose": "P4"
+          }
+        ]
+      }
+    },
+    "result": false,
+    "err": [
+      "oneTrustCookieCategories.web.0.oneTrustCookieCategory must be string",
+      "ketchConsentPurposes.web.0.purpose must be string"
+    ]
+  },
+  {
+    "config": {
+      "containerID": "GTM-XXXX",
+      "serverUrl": "https://gtm.rudder.com",
+      "eventFilteringOption": "whitelistedEvents",
+      "whitelistedEvents": [
+        {
+          "eventName": "registration"
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": {
+          "not": "an array"
+        }
+      },
+      "ketchConsentPurposes": {
+        "web": {
+          "not": "an array"
+        }
+      }
+    },
+    "result": false,
+    "err": ["oneTrustCookieCategories.web must be array", "ketchConsentPurposes.web must be array"]
+  },
+  {
+    "config": {
+      "containerID": "GTM-XXXX",
+      "serverUrl": "https://gtm.rudder.com",
+      "eventFilteringOption": "whitelistedEvents",
+      "whitelistedEvents": [
+        {
+          "eventName": "registration"
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          "not an object",
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          "not an object",
+          {
+            "purpose": "P4"
+          }
+        ]
+      }
+    },
+    "result": false,
+    "err": [
+      "oneTrustCookieCategories.web.0 must be object",
+      "ketchConsentPurposes.web.0 must be object"
+    ]
   }
 ]

--- a/test/data/validation/destinations/gtm.json
+++ b/test/data/validation/destinations/gtm.json
@@ -479,18 +479,7 @@
         "web": true
       },
       "oneTrustCookieCategories": {
-        "someunsupportedsourcetype": [
-          {
-            "oneTrustCookieCategory": "C0001"
-          },
-          {
-            "oneTrustCookieCategory": "C0002"
-          }
-        ],
         "web": [
-          {
-            "someunsupportedkey": "C0001"
-          },
           {
             "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
           },
@@ -500,18 +489,7 @@
         ]
       },
       "ketchConsentPurposes": {
-        "someunsupportedsourcetype": [
-          {
-            "purpose": "P1"
-          },
-          {
-            "purpose": "P2"
-          }
-        ],
         "web": [
-          {
-            "someunsupportedkey": "P1"
-          },
           {
             "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
           },
@@ -523,12 +501,8 @@
     },
     "result": false,
     "err": [
-      "oneTrustCookieCategories must NOT have additional properties",
-      "oneTrustCookieCategories.web.0 must NOT have additional properties",
-      "oneTrustCookieCategories.web.1.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
-      "ketchConsentPurposes must NOT have additional properties",
-      "ketchConsentPurposes.web.0 must NOT have additional properties",
-      "ketchConsentPurposes.web.1.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\""
+      "oneTrustCookieCategories.web.0.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "ketchConsentPurposes.web.0.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\""
     ]
   },
   {

--- a/test/data/validation/destinations/hotjar.json
+++ b/test/data/validation/destinations/hotjar.json
@@ -15,12 +15,7 @@
       ],
       "useNativeSDK": {
         "web": true
-      },
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": ""
-        }
-      ]
+      }
     },
     "result": true
   },
@@ -39,12 +34,7 @@
       ],
       "useNativeSDK": {
         "web": true
-      },
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": ""
-        }
-      ]
+      }
     },
     "result": false,
     "err": [" must have required property 'siteID'"]
@@ -146,5 +136,439 @@
     },
     "result": false,
     "err": ["consentManagement.web.0.provider must be equal to one of the allowed values"]
+  },
+  {
+    "config": {
+      "siteID": "hd000380",
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "siteID": "hd000380",
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          {
+            "oneTrustCookieCategory": "C0003"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          {
+            "purpose": "P3"
+          },
+          {
+            "purpose": "P4"
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "siteID": "hd000380",
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          {
+            "oneTrustCookieCategory": ""
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          {
+            "purpose": ""
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "siteID": "hd000380",
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": []
+      },
+      "ketchConsentPurposes": {
+        "web": []
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "siteID": "hd000380",
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          {
+            "oneTrustCookieCategory": "env.ENVIRONMENT_VARIABLE"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          {
+            "purpose": "env.ENVIRONMENT_VARIABLE"
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "siteID": "hd000380",
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          {
+            "oneTrustCookieCategory": "{{ event.properties.prop1 || 'val' }}"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          {
+            "purpose": "{{ event.properties.prop1 || 'val' }}"
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "siteID": "hd000380",
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": [
+        {
+          "oneTrustCookieCategory": "C0001"
+        },
+        {
+          "oneTrustCookieCategory": "C0002"
+        }
+      ],
+      "ketchConsentPurposes": [
+        {
+          "purpose": "P1"
+        },
+        {
+          "purpose": "P2"
+        }
+      ]
+    },
+    "result": false,
+    "err": ["oneTrustCookieCategories must be object", "ketchConsentPurposes must be object"]
+  },
+  {
+    "config": {
+      "siteID": "hd000380",
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "someunsupportedsourcetype": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "web": [
+          {
+            "someunsupportedkey": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "someunsupportedsourcetype": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "web": [
+          {
+            "someunsupportedkey": "P1"
+          },
+          {
+            "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "purpose": "P4"
+          }
+        ]
+      }
+    },
+    "result": false,
+    "err": [
+      "oneTrustCookieCategories must NOT have additional properties",
+      "oneTrustCookieCategories.web.0 must NOT have additional properties",
+      "oneTrustCookieCategories.web.1.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "ketchConsentPurposes must NOT have additional properties",
+      "ketchConsentPurposes.web.0 must NOT have additional properties",
+      "ketchConsentPurposes.web.1.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\""
+    ]
+  },
+  {
+    "config": {
+      "siteID": "hd000380",
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          {
+            "oneTrustCookieCategory": {
+              "not": "a string"
+            }
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          {
+            "purpose": {
+              "not": "a string"
+            }
+          },
+          {
+            "purpose": "P4"
+          }
+        ]
+      }
+    },
+    "result": false,
+    "err": [
+      "oneTrustCookieCategories.web.0.oneTrustCookieCategory must be string",
+      "ketchConsentPurposes.web.0.purpose must be string"
+    ]
+  },
+  {
+    "config": {
+      "siteID": "hd000380",
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": {
+          "not": "an array"
+        }
+      },
+      "ketchConsentPurposes": {
+        "web": {
+          "not": "an array"
+        }
+      }
+    },
+    "result": false,
+    "err": ["oneTrustCookieCategories.web must be array", "ketchConsentPurposes.web must be array"]
+  },
+  {
+    "config": {
+      "siteID": "hd000380",
+      "eventFilteringOption": "disable",
+      "whitelistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "blacklistedEvents": [
+        {
+          "eventName": ""
+        }
+      ],
+      "useNativeSDK": {
+        "web": true
+      },
+      "oneTrustCookieCategories": {
+        "web": [
+          "not an object",
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "web": [
+          "not an object",
+          {
+            "purpose": "P4"
+          }
+        ]
+      }
+    },
+    "result": false,
+    "err": [
+      "oneTrustCookieCategories.web.0 must be object",
+      "ketchConsentPurposes.web.0 must be object"
+    ]
   }
 ]

--- a/test/data/validation/destinations/hotjar.json
+++ b/test/data/validation/destinations/hotjar.json
@@ -400,18 +400,7 @@
         "web": true
       },
       "oneTrustCookieCategories": {
-        "someunsupportedsourcetype": [
-          {
-            "oneTrustCookieCategory": "C0001"
-          },
-          {
-            "oneTrustCookieCategory": "C0002"
-          }
-        ],
         "web": [
-          {
-            "someunsupportedkey": "C0001"
-          },
           {
             "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
           },
@@ -421,18 +410,7 @@
         ]
       },
       "ketchConsentPurposes": {
-        "someunsupportedsourcetype": [
-          {
-            "purpose": "P1"
-          },
-          {
-            "purpose": "P2"
-          }
-        ],
         "web": [
-          {
-            "someunsupportedkey": "P1"
-          },
           {
             "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
           },
@@ -444,12 +422,8 @@
     },
     "result": false,
     "err": [
-      "oneTrustCookieCategories must NOT have additional properties",
-      "oneTrustCookieCategories.web.0 must NOT have additional properties",
-      "oneTrustCookieCategories.web.1.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
-      "ketchConsentPurposes must NOT have additional properties",
-      "ketchConsentPurposes.web.0 must NOT have additional properties",
-      "ketchConsentPurposes.web.1.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\""
+      "oneTrustCookieCategories.web.0.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "ketchConsentPurposes.web.0.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\""
     ]
   },
   {

--- a/test/data/validation/destinations/mp.json
+++ b/test/data/validation/destinations/mp.json
@@ -665,18 +665,7 @@
       "useUserDefinedPageEventName": true,
       "userDefinedPageEventTemplate": "Viewed {{ name }} page",
       "oneTrustCookieCategories": {
-        "someunsupportedsourcetype": [
-          {
-            "oneTrustCookieCategory": "C0001"
-          },
-          {
-            "oneTrustCookieCategory": "C0002"
-          }
-        ],
         "android": [
-          {
-            "someunsupportedkey": "C0001"
-          },
           {
             "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
           },
@@ -705,18 +694,7 @@
         ]
       },
       "ketchConsentPurposes": {
-        "someunsupportedsourcetype": [
-          {
-            "purpose": "P1"
-          },
-          {
-            "purpose": "P2"
-          }
-        ],
         "android": [
-          {
-            "someunsupportedkey": "P1"
-          },
           {
             "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
           },
@@ -747,15 +725,11 @@
     },
     "result": false,
     "err": [
-      "oneTrustCookieCategories must NOT have additional properties",
-      "oneTrustCookieCategories.android.0 must NOT have additional properties",
-      "oneTrustCookieCategories.android.1.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "oneTrustCookieCategories.android.0.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
       "oneTrustCookieCategories.ios.0.oneTrustCookieCategory must be string",
       "oneTrustCookieCategories.web must be array",
       "oneTrustCookieCategories.unity.0 must be object",
-      "ketchConsentPurposes must NOT have additional properties",
-      "ketchConsentPurposes.android.0 must NOT have additional properties",
-      "ketchConsentPurposes.android.1.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "ketchConsentPurposes.android.0.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
       "ketchConsentPurposes.ios.0.purpose must be string",
       "ketchConsentPurposes.web must be array",
       "ketchConsentPurposes.unity.0 must be object"

--- a/test/data/validation/destinations/mp.json
+++ b/test/data/validation/destinations/mp.json
@@ -58,11 +58,6 @@
           "eventName": "white"
         }
       ],
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
-      ],
       "userDeletionApi": "task",
       "gdprApiToken": "gdprApiToken123",
       "strictMode": true,
@@ -101,12 +96,7 @@
         "web": false
       },
       "strictMode": false,
-      "ignoreDnt": true,
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
-      ]
+      "ignoreDnt": true
     },
     "result": true
   },
@@ -122,12 +112,7 @@
       "eventFilteringOption": "disable",
       "useNativeSDK": {
         "web": false
-      },
-      "oneTrustCookieCategories": [
-        {
-          "oneTrustCookieCategory": "Marketing"
-        }
-      ]
+      }
     },
     "result": true
   },
@@ -340,6 +325,440 @@
     "err": [
       " must have required property 'userDefinedPageEventTemplate'",
       " must match \"then\" schema"
+    ]
+  },
+  {
+    "config": {
+      "token": "2de18c6hf6v45201XXXXd2344b0c128x",
+      "apiSecret": "1c078994c2XXXXX7ffaf71c36a75v227",
+      "dataResidency": "us",
+      "people": false,
+      "setAllTraitsByDefault": false,
+      "consolidatedPageCalls": true,
+      "trackCategorizedPages": false,
+      "trackNamedPages": false,
+      "sourceName": "AWS",
+      "crossSubdomainCookie": true,
+      "persistence": "cookie",
+      "persistenceType": "cookie",
+      "persistenceName": "cookie",
+      "secureCookie": true,
+      "superProperties": [
+        {
+          "property": "super001"
+        }
+      ],
+      "setOnceProperties": [
+        {
+          "property": "setOnce001"
+        }
+      ],
+      "peopleProperties": [
+        {
+          "property": "maidenName"
+        }
+      ],
+      "eventIncrements": [
+        {
+          "property": "triggerName"
+        }
+      ],
+      "propIncrements": [
+        {
+          "property": "extraProps"
+        }
+      ],
+      "groupKeySettings": [
+        {
+          "groupKey": "gg101"
+        }
+      ],
+      "useNativeSDK": {
+        "android": false
+      },
+      "blacklistedEvents": [
+        {
+          "eventName": "black"
+        }
+      ],
+      "whitelistedEvents": [
+        {
+          "eventName": "white"
+        }
+      ],
+      "userDeletionApi": "task",
+      "gdprApiToken": "gdprApiToken123",
+      "strictMode": true,
+      "useUserDefinedPageEventName": true,
+      "userDefinedPageEventTemplate": "Viewed {{ name }} page",
+      "oneTrustCookieCategories": {
+        "android": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "ios": [
+          {
+            "oneTrustCookieCategory": "C0003"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "web": [
+          {
+            "oneTrustCookieCategory": ""
+          }
+        ],
+        "unity": [],
+        "amp": [
+          {
+            "oneTrustCookieCategory": "env.ENVIRONMENT_VARIABLE"
+          }
+        ],
+        "cloud": [
+          {
+            "oneTrustCookieCategory": "{{ event.properties.prop1 || 'val' }}"
+          }
+        ],
+        "warehouse": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "reactnative": [
+          {
+            "oneTrustCookieCategory": "C0003"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "flutter": [
+          {
+            "oneTrustCookieCategory": ""
+          }
+        ],
+        "cordova": [],
+        "shopify": [
+          {
+            "oneTrustCookieCategory": "env.ENVIRONMENT_VARIABLE"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "android": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "ios": [
+          {
+            "purpose": "P3"
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "web": [
+          {
+            "purpose": ""
+          }
+        ],
+        "unity": [],
+        "amp": [
+          {
+            "purpose": "env.ENVIRONMENT_VARIABLE"
+          }
+        ],
+        "cloud": [
+          {
+            "purpose": "{{ event.properties.prop1 || 'val' }}"
+          }
+        ],
+        "warehouse": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "reactnative": [
+          {
+            "purpose": "P3"
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "flutter": [
+          {
+            "purpose": ""
+          }
+        ],
+        "cordova": [],
+        "shopify": [
+          {
+            "purpose": "env.ENVIRONMENT_VARIABLE"
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "token": "2de18c6hf6v45201XXXXd2344b0c128x",
+      "apiSecret": "1c078994c2XXXXX7ffaf71c36a75v227",
+      "dataResidency": "us",
+      "people": false,
+      "setAllTraitsByDefault": false,
+      "consolidatedPageCalls": true,
+      "trackCategorizedPages": false,
+      "trackNamedPages": false,
+      "sourceName": "AWS",
+      "crossSubdomainCookie": true,
+      "persistence": "cookie",
+      "persistenceType": "cookie",
+      "persistenceName": "cookie",
+      "secureCookie": true,
+      "superProperties": [
+        {
+          "property": "super001"
+        }
+      ],
+      "setOnceProperties": [
+        {
+          "property": "setOnce001"
+        }
+      ],
+      "peopleProperties": [
+        {
+          "property": "maidenName"
+        }
+      ],
+      "eventIncrements": [
+        {
+          "property": "triggerName"
+        }
+      ],
+      "propIncrements": [
+        {
+          "property": "extraProps"
+        }
+      ],
+      "groupKeySettings": [
+        {
+          "groupKey": "gg101"
+        }
+      ],
+      "useNativeSDK": {
+        "android": false
+      },
+      "blacklistedEvents": [
+        {
+          "eventName": "black"
+        }
+      ],
+      "whitelistedEvents": [
+        {
+          "eventName": "white"
+        }
+      ],
+      "userDeletionApi": "task",
+      "gdprApiToken": "gdprApiToken123",
+      "strictMode": true,
+      "useUserDefinedPageEventName": true,
+      "userDefinedPageEventTemplate": "Viewed {{ name }} page",
+      "oneTrustCookieCategories": [
+        {
+          "oneTrustCookieCategory": "C0001"
+        },
+        {
+          "oneTrustCookieCategory": "C0002"
+        }
+      ],
+      "ketchConsentPurposes": [
+        {
+          "purpose": "P1"
+        },
+        {
+          "purpose": "P2"
+        }
+      ]
+    },
+    "result": false,
+    "err": ["oneTrustCookieCategories must be object", "ketchConsentPurposes must be object"]
+  },
+  {
+    "config": {
+      "token": "2de18c6hf6v45201XXXXd2344b0c128x",
+      "apiSecret": "1c078994c2XXXXX7ffaf71c36a75v227",
+      "dataResidency": "us",
+      "people": false,
+      "setAllTraitsByDefault": false,
+      "consolidatedPageCalls": true,
+      "trackCategorizedPages": false,
+      "trackNamedPages": false,
+      "sourceName": "AWS",
+      "crossSubdomainCookie": true,
+      "persistence": "cookie",
+      "persistenceType": "cookie",
+      "persistenceName": "cookie",
+      "secureCookie": true,
+      "superProperties": [
+        {
+          "property": "super001"
+        }
+      ],
+      "setOnceProperties": [
+        {
+          "property": "setOnce001"
+        }
+      ],
+      "peopleProperties": [
+        {
+          "property": "maidenName"
+        }
+      ],
+      "eventIncrements": [
+        {
+          "property": "triggerName"
+        }
+      ],
+      "propIncrements": [
+        {
+          "property": "extraProps"
+        }
+      ],
+      "groupKeySettings": [
+        {
+          "groupKey": "gg101"
+        }
+      ],
+      "useNativeSDK": {
+        "android": false
+      },
+      "blacklistedEvents": [
+        {
+          "eventName": "black"
+        }
+      ],
+      "whitelistedEvents": [
+        {
+          "eventName": "white"
+        }
+      ],
+      "userDeletionApi": "task",
+      "gdprApiToken": "gdprApiToken123",
+      "strictMode": true,
+      "useUserDefinedPageEventName": true,
+      "userDefinedPageEventTemplate": "Viewed {{ name }} page",
+      "oneTrustCookieCategories": {
+        "someunsupportedsourcetype": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "android": [
+          {
+            "someunsupportedkey": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "ios": [
+          {
+            "oneTrustCookieCategory": {
+              "not": "a string"
+            }
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "web": {
+          "not": "an array"
+        },
+        "unity": [
+          "not an object",
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "someunsupportedsourcetype": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "android": [
+          {
+            "someunsupportedkey": "P1"
+          },
+          {
+            "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "ios": [
+          {
+            "purpose": {
+              "not": "a string"
+            }
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "web": {
+          "not": "an array"
+        },
+        "unity": [
+          "not an object",
+          {
+            "purpose": "P4"
+          }
+        ]
+      }
+    },
+    "result": false,
+    "err": [
+      "oneTrustCookieCategories must NOT have additional properties",
+      "oneTrustCookieCategories.android.0 must NOT have additional properties",
+      "oneTrustCookieCategories.android.1.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "oneTrustCookieCategories.ios.0.oneTrustCookieCategory must be string",
+      "oneTrustCookieCategories.web must be array",
+      "oneTrustCookieCategories.unity.0 must be object",
+      "ketchConsentPurposes must NOT have additional properties",
+      "ketchConsentPurposes.android.0 must NOT have additional properties",
+      "ketchConsentPurposes.android.1.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "ketchConsentPurposes.ios.0.purpose must be string",
+      "ketchConsentPurposes.web must be array",
+      "ketchConsentPurposes.unity.0 must be object"
     ]
   }
 ]

--- a/test/data/validation/destinations/postgres.json
+++ b/test/data/validation/destinations/postgres.json
@@ -798,18 +798,7 @@
       "accessKeyID": "test-access-key-id",
       "accessKey": "test-access-key",
       "oneTrustCookieCategories": {
-        "someunsupportedsourcetype": [
-          {
-            "oneTrustCookieCategory": "C0001"
-          },
-          {
-            "oneTrustCookieCategory": "C0002"
-          }
-        ],
         "android": [
-          {
-            "someunsupportedkey": "C0001"
-          },
           {
             "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
           },
@@ -838,18 +827,7 @@
         ]
       },
       "ketchConsentPurposes": {
-        "someunsupportedsourcetype": [
-          {
-            "purpose": "P1"
-          },
-          {
-            "purpose": "P2"
-          }
-        ],
         "android": [
-          {
-            "someunsupportedkey": "P1"
-          },
           {
             "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
           },
@@ -880,15 +858,11 @@
     },
     "result": false,
     "err": [
-      "oneTrustCookieCategories must NOT have additional properties",
-      "oneTrustCookieCategories.android.0 must NOT have additional properties",
-      "oneTrustCookieCategories.android.1.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "oneTrustCookieCategories.android.0.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
       "oneTrustCookieCategories.ios.0.oneTrustCookieCategory must be string",
       "oneTrustCookieCategories.web must be array",
       "oneTrustCookieCategories.unity.0 must be object",
-      "ketchConsentPurposes must NOT have additional properties",
-      "ketchConsentPurposes.android.0 must NOT have additional properties",
-      "ketchConsentPurposes.android.1.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "ketchConsentPurposes.android.0.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
       "ketchConsentPurposes.ios.0.purpose must be string",
       "ketchConsentPurposes.web must be array",
       "ketchConsentPurposes.unity.0 must be object"

--- a/test/data/validation/destinations/postgres.json
+++ b/test/data/validation/destinations/postgres.json
@@ -609,5 +609,289 @@
     },
     "result": false,
     "err": ["consentManagement.android.0.provider must be equal to one of the allowed values"]
+  },
+  {
+    "config": {
+      "host": "test-host",
+      "database": "test-database",
+      "user": "test-user",
+      "password": "test-password",
+      "port": "0000",
+      "sslMode": "disable",
+      "bucketProvider": "S3",
+      "syncFrequency": "30",
+      "useRudderStorage": false,
+      "bucketName": "test-bucket",
+      "accessKeyID": "test-access-key-id",
+      "accessKey": "test-access-key",
+      "oneTrustCookieCategories": {
+        "android": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "ios": [
+          {
+            "oneTrustCookieCategory": "C0003"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "web": [
+          {
+            "oneTrustCookieCategory": ""
+          }
+        ],
+        "unity": [],
+        "amp": [
+          {
+            "oneTrustCookieCategory": "env.ENVIRONMENT_VARIABLE"
+          }
+        ],
+        "cloud": [
+          {
+            "oneTrustCookieCategory": "{{ event.properties.prop1 || 'val' }}"
+          }
+        ],
+        "reactnative": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "cloudSource": [
+          {
+            "oneTrustCookieCategory": "C0003"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "flutter": [
+          {
+            "oneTrustCookieCategory": ""
+          }
+        ],
+        "cordova": [],
+        "shopify": [
+          {
+            "oneTrustCookieCategory": "env.ENVIRONMENT_VARIABLE"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "android": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "ios": [
+          {
+            "purpose": "P3"
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "web": [
+          {
+            "purpose": ""
+          }
+        ],
+        "unity": [],
+        "amp": [
+          {
+            "purpose": "env.ENVIRONMENT_VARIABLE"
+          }
+        ],
+        "cloud": [
+          {
+            "purpose": "{{ event.properties.prop1 || 'val' }}"
+          }
+        ],
+        "reactnative": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "cloudSource": [
+          {
+            "purpose": "P3"
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "flutter": [
+          {
+            "purpose": ""
+          }
+        ],
+        "cordova": [],
+        "shopify": [
+          {
+            "purpose": "env.ENVIRONMENT_VARIABLE"
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "host": "test-host",
+      "database": "test-database",
+      "user": "test-user",
+      "password": "test-password",
+      "port": "0000",
+      "sslMode": "disable",
+      "bucketProvider": "S3",
+      "syncFrequency": "30",
+      "useRudderStorage": false,
+      "bucketName": "test-bucket",
+      "accessKeyID": "test-access-key-id",
+      "accessKey": "test-access-key",
+      "oneTrustCookieCategories": [
+        {
+          "oneTrustCookieCategory": "C0001"
+        },
+        {
+          "oneTrustCookieCategory": "C0002"
+        }
+      ],
+      "ketchConsentPurposes": [
+        {
+          "purpose": "P1"
+        },
+        {
+          "purpose": "P2"
+        }
+      ]
+    },
+    "result": false,
+    "err": ["oneTrustCookieCategories must be object", "ketchConsentPurposes must be object"]
+  },
+  {
+    "config": {
+      "host": "test-host",
+      "database": "test-database",
+      "user": "test-user",
+      "password": "test-password",
+      "port": "0000",
+      "sslMode": "disable",
+      "bucketProvider": "S3",
+      "syncFrequency": "30",
+      "useRudderStorage": false,
+      "bucketName": "test-bucket",
+      "accessKeyID": "test-access-key-id",
+      "accessKey": "test-access-key",
+      "oneTrustCookieCategories": {
+        "someunsupportedsourcetype": [
+          {
+            "oneTrustCookieCategory": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "C0002"
+          }
+        ],
+        "android": [
+          {
+            "someunsupportedkey": "C0001"
+          },
+          {
+            "oneTrustCookieCategory": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "ios": [
+          {
+            "oneTrustCookieCategory": {
+              "not": "a string"
+            }
+          },
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ],
+        "web": {
+          "not": "an array"
+        },
+        "unity": [
+          "not an object",
+          {
+            "oneTrustCookieCategory": "C0004"
+          }
+        ]
+      },
+      "ketchConsentPurposes": {
+        "someunsupportedsourcetype": [
+          {
+            "purpose": "P1"
+          },
+          {
+            "purpose": "P2"
+          }
+        ],
+        "android": [
+          {
+            "someunsupportedkey": "P1"
+          },
+          {
+            "purpose": "more than 100 characters string - AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "ios": [
+          {
+            "purpose": {
+              "not": "a string"
+            }
+          },
+          {
+            "purpose": "P4"
+          }
+        ],
+        "web": {
+          "not": "an array"
+        },
+        "unity": [
+          "not an object",
+          {
+            "purpose": "P4"
+          }
+        ]
+      }
+    },
+    "result": false,
+    "err": [
+      "oneTrustCookieCategories must NOT have additional properties",
+      "oneTrustCookieCategories.android.0 must NOT have additional properties",
+      "oneTrustCookieCategories.android.1.oneTrustCookieCategory must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "oneTrustCookieCategories.ios.0.oneTrustCookieCategory must be string",
+      "oneTrustCookieCategories.web must be array",
+      "oneTrustCookieCategories.unity.0 must be object",
+      "ketchConsentPurposes must NOT have additional properties",
+      "ketchConsentPurposes.android.0 must NOT have additional properties",
+      "ketchConsentPurposes.android.1.purpose must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$\"",
+      "ketchConsentPurposes.ios.0.purpose must be string",
+      "ketchConsentPurposes.web must be array",
+      "ketchConsentPurposes.unity.0 must be object"
+    ]
   }
 ]


### PR DESCRIPTION
## What are the changes introduced in this PR?

As we plan to support generic consent management for client-side SDKs, to make the backward compatibility feasible, we must define the legacy fields at the source-type level instead of `defaultConfig`.

This PR addresses it for a subset of destinations (to start with). Also, extended the Ketch consent management for all the destinations.
Also, test data has been created for both the consent management fields.

Other changes:
- Updated labels of consent management fields to specify "IDs".
- deployment script
  - Added request timeout
  - Formatted JSON output
  - "na" changed to "N/A"
  - Beautified output formatting

Note that the changes to all the destinations were done using a Python script (`legacyConsentConfigMigrator.py`) to automate the process. This is a temporary script which will be removed by the end of this effort.

**Before:**
GA4
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/d71e3838-250b-4b2b-a8c1-7d25ce405b1b">

Amplitude:
<img width="1450" alt="image" src="https://github.com/user-attachments/assets/10d50495-5242-410a-99c1-921b76d763fe">

Postgres:
<img width="1441" alt="image" src="https://github.com/user-attachments/assets/be227982-0ca0-49e3-9fc7-91f5f1e56107">

Mixpanel:
<img width="1457" alt="image" src="https://github.com/user-attachments/assets/ec2dac82-d9ca-4fd2-9ce1-68660054853d">

GTM:
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/ecc95f35-3118-43c4-ae5d-b269963eb151">

Hotjar:
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/3ae9643e-e09d-4f7e-85fe-e6edcb4a451c">

**After:**
GA4
<img width="1433" alt="image" src="https://github.com/user-attachments/assets/8fa4eaeb-9be2-423c-9ee6-470ec52e5aab">


Amplitude:
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/79d1bc3e-edb0-4152-ac93-a4d0ba35b710">


Postgres:
<img width="1435" alt="image" src="https://github.com/user-attachments/assets/d822a881-4a03-4c91-b5c3-d3515c0ed4b7">


Mixpanel:
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/c38e8ab3-91e4-4a56-91f4-d7478cd37450">
<img width="1453" alt="image" src="https://github.com/user-attachments/assets/8269e229-6de3-420a-8169-fb5ec12e2d58">


GTM:
<img width="1449" alt="image" src="https://github.com/user-attachments/assets/5cf8815c-0c55-4701-878b-0bad443732f2">


Hotjar:
<img width="1446" alt="image" src="https://github.com/user-attachments/assets/82aeaa50-cc3d-4a74-91eb-5125b86861d6">


## What is the related Linear task?

https://linear.app/rudderstack/issue/SDK-1540/make-legacy-consent-fields-source-type-specific-for-a-subset-of

## Please explain the objectives of your changes below

To make consent management configuration data backward compatible.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] I have executed schemaGenerator tests and updated schema if needed

- [x] Are sensitive fields marked as secret in definition config?

- [x] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
