### PR TITLE
fix: kafka topic name regex

### DIFF
--- a/src/configurations/destinations/kafka/ui-config.json
+++ b/src/configurations/destinations/kafka/ui-config.json
@@ -35,7 +35,7 @@
                     "label": "Topic Name",
                     "note": "Please enter the topic name",
                     "configKey": "topic",
-                    "regex": "^[a-zA-Z0-9_\\-]{1,249}$",
+                    "regex": "^[a-zA-Z0-9_.\\-]{1,249}$",
                     "regexErrorMessage": "Invalid Topic Name",
                     "placeholder": "e.g: test-topic"
                   }

--- a/test/data/validation/destinations/kafka.json
+++ b/test/data/validation/destinations/kafka.json
@@ -34,6 +34,14 @@
   {
     "config": {
       "hostName": "rudder.com",
+      "port": "65535",
+      "topic": "test.Topic-1_2_3"
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "hostName": "rudder.com",
       "port": "443",
       "topic": "test-topic",
       "sslEnabled": true


### PR DESCRIPTION
## What are the changes introduced in this PR?

- Modified kafka topic name regex to handle dots `(.)` as well.

## What is the related Linear task?

Resolves PIPE-1548


### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
