### PR TITLE
feat: enable support for RN device mode in the Facebook App Events

### DIFF
--- a/src/configurations/destinations/fb/db-config.json
+++ b/src/configurations/destinations/fb/db-config.json
@@ -33,7 +33,8 @@
       "cloud": ["page", "screen", "track"],
       "device": {
         "android": ["identify", "screen", "track"],
-        "ios": ["identify", "screen", "track"]
+        "ios": ["identify", "screen", "track"],
+        "reactnative": ["identify", "screen", "track"]
       }
     },
     "supportedConnectionModes": {
@@ -42,7 +43,7 @@
       "web": ["cloud"],
       "unity": ["cloud"],
       "amp": ["cloud"],
-      "reactnative": ["cloud"],
+      "reactnative": ["cloud", "device"],
       "flutter": ["cloud"],
       "cordova": ["cloud"],
       "shopify": ["cloud"],
@@ -98,6 +99,7 @@
         "ketchConsentPurposes"
       ],
       "reactnative": [
+        "useNativeSDK",
         "connectionMode",
         "consentManagement",
         "oneTrustCookieCategories",


### PR DESCRIPTION
## What are the changes introduced in this PR?

- In this PR, we enabled support for the device mode in the React Native source for Facebook App Events.
<img width="1429" alt="image" src="https://github.com/user-attachments/assets/eb7fe25b-5e81-4557-868d-a83a8b8ebba6">


## What is the related Linear task?

Resolves [SDK-2290](https://linear.app/rudderstack/issue/SDK-2290/changes-in-control-plane-regrading-rn-facebook-app-events-integration)

## Please explain the objectives of your changes below

We already support device mode for the Facebook App Events mobile integrations. Now we created the new integration for the React Native and we need to add support for the device mode in that.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] I have executed schemaGenerator tests and updated schema if needed

- [x] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [x] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
