### PR TITLE
feat(fb_custom_audience): hide particular fields from ui config when VDMv2 is enabled

### DIFF
--- a/src/configurations/destinations/fb_custom_audience/ui-config.json
+++ b/src/configurations/destinations/fb_custom_audience/ui-config.json
@@ -464,7 +464,22 @@
                     ],
                     "default": "NA"
                   }
-                ]
+                ],
+                "preRequisites": {
+                  "fields": [
+                    {
+                      "configKey": "connectionMode.cloud",
+                      "value": "cloud"
+                    }
+                  ],
+                  "featureFlagAndFieldCondition": "or",
+                  "featureFlags": [
+                    {
+                      "configKey": "AMP_vdm-next",
+                      "value": false
+                    }
+                  ]
+                }
               }
             ]
           },

--- a/src/configurations/destinations/fb_custom_audience/ui-config.json
+++ b/src/configurations/destinations/fb_custom_audience/ui-config.json
@@ -472,7 +472,7 @@
                       "value": "cloud"
                     }
                   ],
-                  "featureFlagAndFieldCondition": "or",
+                  "prerequisitesCondition": "or",
                   "featureFlags": [
                     {
                       "configKey": "AMP_vdm-next",


### PR DESCRIPTION
## What are the changes introduced in this PR?

Hide particular fields from ui config when VDMv2 is enabled for FBCA

## What is the related Linear task?

Resolves INT-2648

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
