### PR TITLE
fix: salesforce v2 sandbox config remove

### DIFF
--- a/src/configurations/destinations/salesforce_oauth/db-config.json
+++ b/src/configurations/destinations/salesforce_oauth/db-config.json
@@ -27,7 +27,7 @@
     ],
     "supportedMessageTypes": ["identify"],
     "destConfig": {
-      "defaultConfig": ["rudderAccountId", "mapProperties", "sandbox", "useContactId"],
+      "defaultConfig": ["rudderAccountId", "mapProperties", "useContactId"],
       "android": [
         "connectionMode",
         "consentManagement",

--- a/src/configurations/destinations/salesforce_oauth/schema.json
+++ b/src/configurations/destinations/salesforce_oauth/schema.json
@@ -8,10 +8,6 @@
         "type": "boolean",
         "default": true
       },
-      "sandbox": {
-        "type": "boolean",
-        "default": false
-      },
       "useContactId": {
         "type": "boolean",
         "default": false

--- a/src/configurations/destinations/salesforce_oauth/ui-config.json
+++ b/src/configurations/destinations/salesforce_oauth/ui-config.json
@@ -11,12 +11,6 @@
         },
         {
           "type": "checkbox",
-          "label": "Sandbox mode",
-          "value": "sandbox",
-          "default": false
-        },
-        {
-          "type": "checkbox",
           "label": "Use contactId for converted leads",
           "value": "useContactId",
           "default": false,

--- a/test/data/validation/destinations/salesforce_oauth.json
+++ b/test/data/validation/destinations/salesforce_oauth.json
@@ -2,7 +2,7 @@
   {
     "config": {
       "mapProperties": true,
-      "sandbox": false,
+     
       "useContactId": true
     },
     "result": true
@@ -10,7 +10,7 @@
   {
     "config": {
       "mapProperties": true,
-      "sandbox": false,
+     
       "useContactId": true
     },
     "result": true
@@ -18,25 +18,16 @@
   {
     "config": {
       "mapProperties": true,
-      "sandbox": false,
+     
       "useContactId": true
     },
     "result": true
-  },
-  {
-    "config": {
-      "mapProperties": true,
-      "sandbox": "random",
-      "useContactId": true
-    },
-    "result": false,
-    "err": ["sandbox must be boolean"]
   },
   {
     "testTitle": "With valid multiple consent management providers config",
     "config": {
       "mapProperties": true,
-      "sandbox": false,
+     
       "useContactId": true,
       "consentManagement": {
         "web": [
@@ -70,7 +61,7 @@
     "testTitle": "With consent management custom provider config and invalid resolutionStrategy value",
     "config": {
       "mapProperties": true,
-      "sandbox": false,
+     
       "useContactId": true,
       "consentManagement": {
         "android": [
@@ -91,7 +82,7 @@
     "testTitle": "With consent management custom provider config and no resolutionStrategy value",
     "config": {
       "mapProperties": true,
-      "sandbox": false,
+     
       "useContactId": true,
       "consentManagement": {
         "android": [
@@ -111,7 +102,7 @@
     "testTitle": "With consent management OneTrust provider config and no resolutionStrategy value",
     "config": {
       "mapProperties": true,
-      "sandbox": false,
+     
       "useContactId": true,
       "consentManagement": {
         "android": [
@@ -127,7 +118,7 @@
     "testTitle": "With consent management custom provider config invalid provider value",
     "config": {
       "mapProperties": true,
-      "sandbox": false,
+     
       "useContactId": true,
       "consentManagement": {
         "android": [
@@ -143,7 +134,7 @@
   {
     "config": {
       "mapProperties": true,
-      "sandbox": false,
+     
       "useContactId": true,
       "oneTrustCookieCategories": {
         "android": [
@@ -263,7 +254,7 @@
   {
     "config": {
       "mapProperties": true,
-      "sandbox": false,
+     
       "useContactId": true,
       "oneTrustCookieCategories": [
         {
@@ -288,7 +279,7 @@
   {
     "config": {
       "mapProperties": true,
-      "sandbox": false,
+     
       "useContactId": true,
       "oneTrustCookieCategories": {
         "android": [


### PR DESCRIPTION
## What are the changes introduced in this PR?

Salesforce v2 sandbox support is not provided in rudder-auth. This config, being here were confusing the customer and also a bad user experience. hence removing it from UI and also will include that is salesforce doc.

## What is the related Linear task?

Resolves INT-2740

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
