### PR TITLE
chore: remove number prefix from title

### DIFF
--- a/src/configurations/destinations/azure_datalake/ui-config.json
+++ b/src/configurations/destinations/azure_datalake/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Credentials",
+      "title": "Connection Credentials",
       "fields": [
         {
           "type": "textInput",

--- a/src/configurations/destinations/azure_synapse/ui-config.json
+++ b/src/configurations/destinations/azure_synapse/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Credentials",
+      "title": "Connection Credentials",
       "fields": [
         {
           "type": "textInput",

--- a/src/configurations/destinations/digital_ocean_spaces/ui-config.json
+++ b/src/configurations/destinations/digital_ocean_spaces/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Settings",
+      "title": "Connection Settings",
       "fields": [
         {
           "type": "textInput",

--- a/src/configurations/destinations/firebase/ui-config.json
+++ b/src/configurations/destinations/firebase/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Native SDK",
+      "title": "Native SDK",
       "fields": [
         {
           "type": "defaultCheckbox",

--- a/src/configurations/destinations/gcs/ui-config.json
+++ b/src/configurations/destinations/gcs/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Settings",
+      "title": "Connection Settings",
       "fields": [
         {
           "type": "textInput",

--- a/src/configurations/destinations/gcs_datalake/ui-config.json
+++ b/src/configurations/destinations/gcs_datalake/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Credentials",
+      "title": "Connection Credentials",
       "fields": [
         {
           "type": "textInput",

--- a/src/configurations/destinations/googlepubsub/ui-config.json
+++ b/src/configurations/destinations/googlepubsub/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Settings",
+      "title": "Connection Settings",
       "fields": [
         {
           "type": "textInput",

--- a/src/configurations/destinations/gtm/ui-config.json
+++ b/src/configurations/destinations/gtm/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Settings",
+      "title": "Connection Settings",
       "fields": [
         {
           "type": "textInput",
@@ -24,7 +24,7 @@
       ]
     },
     {
-      "title": "2. Native SDK",
+      "title": "Native SDK",
       "fields": [
         {
           "type": "defaultCheckbox",

--- a/src/configurations/destinations/hotjar/ui-config.json
+++ b/src/configurations/destinations/hotjar/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Settings",
+      "title": "Connection Settings",
       "fields": [
         {
           "type": "textInput",
@@ -15,7 +15,7 @@
       ]
     },
     {
-      "title": "2. Native SDK",
+      "title": "Native SDK",
       "fields": [
         {
           "type": "defaultCheckbox",

--- a/src/configurations/destinations/keen/ui-config.json
+++ b/src/configurations/destinations/keen/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Settings",
+      "title": "Connection Settings",
       "fields": [
         {
           "type": "textInput",
@@ -23,7 +23,7 @@
       ]
     },
     {
-      "title": "2. Native SDK",
+      "title": "Native SDK",
       "fields": [
         {
           "type": "checkbox",
@@ -34,7 +34,7 @@
       ]
     },
     {
-      "title": "3. Add On",
+      "title": "Add On",
       "fields": [
         {
           "type": "checkbox",

--- a/src/configurations/destinations/mailchimp/ui-config.json
+++ b/src/configurations/destinations/mailchimp/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Settings",
+      "title": "Connection Settings",
       "fields": [
         {
           "type": "textInput",
@@ -33,7 +33,7 @@
       ]
     },
     {
-      "title": "2. Event Map Setting",
+      "title": "Event Map Setting",
       "fields": [
         {
           "type": "checkbox",

--- a/src/configurations/destinations/minio/ui-config.json
+++ b/src/configurations/destinations/minio/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Settings",
+      "title": "Connection Settings",
       "fields": [
         {
           "type": "textInput",

--- a/src/configurations/destinations/mssql/ui-config.json
+++ b/src/configurations/destinations/mssql/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Credentials",
+      "title": "Connection Credentials",
       "fields": [
         {
           "type": "textInput",

--- a/src/configurations/destinations/personalize/ui-config.json
+++ b/src/configurations/destinations/personalize/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Credentials",
+      "title": "Connection Credentials",
       "fields": [
         {
           "type": "checkbox",
@@ -64,7 +64,7 @@
       ]
     },
     {
-      "title": "2. Information on Dataset Group",
+      "title": "Information on Dataset Group",
       "fields": [
         {
           "type": "textInput",
@@ -87,7 +87,7 @@
       ]
     },
     {
-      "title": "3. Operational Choice",
+      "title": "Operational Choice",
       "fields": [
         {
           "type": "singleSelect",

--- a/src/configurations/destinations/quantummetric/ui-config.json
+++ b/src/configurations/destinations/quantummetric/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Settings",
+      "title": "Connection Settings",
       "fields": [
         {
           "type": "textInput",
@@ -15,7 +15,7 @@
       ]
     },
     {
-      "title": "2. Native SDK",
+      "title": "Native SDK",
       "fields": [
         {
           "type": "defaultCheckbox",

--- a/src/configurations/destinations/redis/ui-config.json
+++ b/src/configurations/destinations/redis/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Settings",
+      "title": "Connection Settings",
       "fields": [
         {
           "type": "textInput",

--- a/src/configurations/destinations/s3/ui-config.json
+++ b/src/configurations/destinations/s3/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Settings",
+      "title": "Connection Settings",
       "fields": [
         {
           "type": "textInput",

--- a/src/configurations/destinations/snowflake/ui-config.json
+++ b/src/configurations/destinations/snowflake/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Credentials",
+      "title": "Connection Credentials",
       "fields": [
         {
           "type": "textInput",

--- a/src/configurations/destinations/splitio/ui-config.json
+++ b/src/configurations/destinations/splitio/ui-config.json
@@ -1,7 +1,7 @@
 {
   "uiConfig": [
     {
-      "title": "1. Connection Credentials",
+      "title": "Connection Credentials",
       "fields": [
         {
           "type": "textInput",
@@ -22,7 +22,7 @@
       ]
     },
     {
-      "title": "2. Information on Traffic",
+      "title": "Information on Traffic",
       "fields": [
         {
           "type": "textInput",


### PR DESCRIPTION
## What are the changes introduced in this PR?

Remove number prefix from titles to align with the rest.

## Before
<img width="969" alt="Screenshot 2024-10-21 at 11 05 44" src="https://github.com/user-attachments/assets/1d026c59-4e1e-4258-9a07-9a019ffc82e1">


## After
<img width="1010" alt="Screenshot 2024-10-21 at 11 07 43" src="https://github.com/user-attachments/assets/eb37cdba-1964-4dc2-831e-d8fa5a9b80ce">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Simplified titles for the "Connection Credentials" section across various configuration files by removing the numeric prefix.
  - Updated titles for several sections, including "Native SDK" and "Event Map Setting," enhancing readability.

- **Bug Fixes**
  - No functional changes were made; all configurations remain intact and operational.

These updates enhance clarity in the user interface without impacting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->