### PR TITLE
chore: snowpipe streaming category not a warehouse

### DIFF
--- a/src/configurations/destinations/snowpipe_streaming/db-config.json
+++ b/src/configurations/destinations/snowpipe_streaming/db-config.json
@@ -1,7 +1,6 @@
 {
   "name": "SNOWPIPE_STREAMING",
   "displayName": "Snowpipe Streaming",
-  "category": "warehouse",
   "config": {
     "transformAtV1": "processor",
     "saveDestinationResponse": true,


### PR DESCRIPTION
## What are the changes introduced in this PR?

- Moving Snowpipe streaming to the event stream category (setting it as empty).

## What is the related Linear task?

- Resolves PIPE-1684


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the category field in the Snowpipe Streaming configuration to improve clarity in categorization.
  
- **Chores**
	- No structural changes made to the overall configuration logic or options section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->