### PR TITLE
fix(MP): now showing setOnceProperties in cloud mode also

### DIFF
--- a/src/configurations/destinations/mp/ui-config.json
+++ b/src/configurations/destinations/mp/ui-config.json
@@ -188,6 +188,22 @@
                     "regex": "^(.{0,100})$",
                     "regexErrorMessage": "Invalid Property Name",
                     "placeholder": "e.g: Cart-Value"
+                  },
+                  {
+                    "type": "tagInput",
+                    "configKey": "setOnceProperties",
+                    "label": "Properties to set only once",
+                    "note": [
+                      "Set this for those properties who's values are not supposed to change in profile level.",
+                      {
+                        "text": "Reference",
+                        "link": "https://developer.mixpanel.com/reference/profile-set-property-once"
+                      }
+                    ],
+                    "tagKey": "property",
+                    "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+                    "regexErrorMessage": "Invalid Property Name",
+                    "placeholder": "e.g: joiningDate"
                   }
                 ]
               },
@@ -491,16 +507,6 @@
           "regex": "^(.{0,100})$",
           "regexErrorMessage": "Invalid Property Name",
           "placeholder": "e.g: residence"
-        },
-        {
-          "type": "tagInput",
-          "configKey": "setOnceProperties",
-          "label": "Properties to set only once",
-          "note": "Set this for those properties who's values are not supposed to change in profile level. Reference: https://developer.mixpanel.com/reference/profile-set-property-once",
-          "tagKey": "property",
-          "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
-          "regexErrorMessage": "Invalid Property Name",
-          "placeholder": "e.g: joiningDate"
         },
         {
           "type": "tagInput",


### PR DESCRIPTION
## What are the changes introduced in this PR?

Now showing setOnceProperties in cloud mode also

## What is the related Linear task?

Resolves INT-2857

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
