### PR TITLE
fix: bq partitioning for additional columns

### DIFF
--- a/src/configurations/destinations/bq/schema.json
+++ b/src/configurations/destinations/bq/schema.json
@@ -35,7 +35,7 @@
       },
       "partitionColumn": {
         "type": "string",
-        "pattern": "^(_PARTITIONTIME|loaded_at|received_at)$",
+        "pattern": "^(_PARTITIONTIME|loaded_at|received_at|timestamp|sent_at|original_timestamp)$",
         "default": "_PARTITIONTIME"
       },
       "partitionType": {

--- a/src/configurations/destinations/bq/ui-config.json
+++ b/src/configurations/destinations/bq/ui-config.json
@@ -160,6 +160,18 @@
             {
               "name": "Received At",
               "value": "received_at"
+            },
+            {
+              "name": "Timestamp",
+              "value": "timestamp"
+            },
+            {
+              "name": "Sent At",
+              "value": "sent_at"
+            },
+            {
+              "name": "Original Timestamp",
+              "value": "original_timestamp"
             }
           ],
           "defaultOption": {

--- a/test/data/validation/destinations/bq.json
+++ b/test/data/validation/destinations/bq.json
@@ -52,6 +52,54 @@
       "bucketName": "test-bucket",
       "prefix": "xyzxx",
       "namespace": "eu_new3",
+      "partitionColumn": "sent_at",
+      "partitionType": "hour",
+      "credentials": "{}",
+      "syncFrequency": "30",
+      "testConnection": false,
+      "testConnectionTS": 1621402528550
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "project": "test-gcs-project",
+      "location": "",
+      "bucketName": "test-bucket",
+      "prefix": "xyzxx",
+      "namespace": "eu_new3",
+      "partitionColumn": "timestamp",
+      "partitionType": "hour",
+      "credentials": "{}",
+      "syncFrequency": "30",
+      "testConnection": false,
+      "testConnectionTS": 1621402528550
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "project": "test-gcs-project",
+      "location": "",
+      "bucketName": "test-bucket",
+      "prefix": "xyzxx",
+      "namespace": "eu_new3",
+      "partitionColumn": "original_timestamp",
+      "partitionType": "hour",
+      "credentials": "{}",
+      "syncFrequency": "30",
+      "testConnection": false,
+      "testConnectionTS": 1621402528550
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "project": "test-gcs-project",
+      "location": "",
+      "bucketName": "test-bucket",
+      "prefix": "xyzxx",
+      "namespace": "eu_new3",
       "partitionColumn": "invalid",
       "partitionType": "day",
       "credentials": "{}",
@@ -61,7 +109,7 @@
     },
     "result": false,
     "error": [
-      "partitionColumn must match pattern \"^(_PARTITIONTIME|loaded_at|received_at|timestamp)$\""
+      "partitionColumn must match pattern \"^(_PARTITIONTIME|loaded_at|received_at|timestamp|sent_at|original_timestamp)$\""
     ]
   },
   {


### PR DESCRIPTION
## What are the changes introduced in this PR?

- BQ partitioning is used for additional columns like `sent_at`, `timestamp`, and `original_timestamp`.

## What is the related Linear task?

- Resolves PIPE-1731


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded options for the "Partition Column" in BigQuery configurations, now including "Sent At," "Timestamp," and "Original Timestamp."
	- Enhanced validation logic to support new partition column values.

- **Bug Fixes**
	- Updated error messages for invalid partition column values to reflect the new valid options.

- **Documentation**
	- Revised guidance on using category IDs for consent management settings, marking category names as deprecated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->