### PR TITLE
chore: update config for klaviyo and ga4 v2

### DIFF
--- a/src/configurations/destinations/ga4_v2/db-config.json
+++ b/src/configurations/destinations/ga4_v2/db-config.json
@@ -154,6 +154,10 @@
   },
   "options": {
     "isBeta": false,
-    "supportsCustomMappings": true
+    "supportsCustomMappings": true,
+    "hidden": {
+      "featureFlagName": "AMP_ga4_v2",
+      "featureFlagValue": false
+    }
   }
 }

--- a/src/configurations/destinations/klaviyo/ui-config.json
+++ b/src/configurations/destinations/klaviyo/ui-config.json
@@ -38,7 +38,7 @@
                     "configKey": "apiVersion",
                     "options": [
                       {
-                        "label": "2023-02-22 (Will be removed by H2'2025)",
+                        "label": "2023-02-22 (Will be removed by Feb 2025)",
                         "value": "v1"
                       },
                       {
@@ -46,7 +46,7 @@
                         "value": "v2"
                       }
                     ],
-                    "default": "v1",
+                    "default": "v2",
                     "footerNote": "Please Select the API version to use"
                   }
                 ]


### PR DESCRIPTION
## What are the changes introduced in this PR?

Update default API version for Klaviyo and enable feature flag for ga4 v2
