### PR TITLE
chore: remove beta and make v2 default version in klaviyo dest ui

### DIFF
--- a/src/configurations/destinations/klaviyo/schema.json
+++ b/src/configurations/destinations/klaviyo/schema.json
@@ -11,7 +11,7 @@
       "apiVersion": {
         "type": "string",
         "enum": ["v1", "v2"],
-        "default": "v1"
+        "default": "v2"
       },
       "privateApiKey": {
         "type": "string",

--- a/src/configurations/destinations/klaviyo/ui-config.json
+++ b/src/configurations/destinations/klaviyo/ui-config.json
@@ -38,7 +38,7 @@
                     "configKey": "apiVersion",
                     "options": [
                       {
-                        "label": "2023-02-22 (Will be removed by H2'2025)",
+                        "label": "2023-02-22 (Will be removed by Feb'25)",
                         "value": "v1"
                       },
                       {

--- a/src/configurations/destinations/klaviyo/ui-config.json
+++ b/src/configurations/destinations/klaviyo/ui-config.json
@@ -42,11 +42,11 @@
                         "value": "v1"
                       },
                       {
-                        "label": "2024-06-15 (Beta)",
+                        "label": "2024-06-15",
                         "value": "v2"
                       }
                     ],
-                    "default": "v1",
+                    "default": "v2",
                     "footerNote": "Please Select the API version to use"
                   }
                 ]


### PR DESCRIPTION
## What are the changes introduced in this PR?

We are updating the Klaviyo UI
- remove the beta tag in the new api
- make it the default option when creating a new Klaviyo destination

## What is the related Linear task?

Resolves INT-3095

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated Klaviyo integration configuration with the latest API version.
  - Changed default API version from "v1" to "v2".
- **Documentation**
  - Removed "(Beta)" label from API version, indicating stable release.
  - Updated labels for API version options for clarity on removal timelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->