### PR TITLE
chore: enable ga4 v2 as beta

### DIFF
--- a/src/configurations/destinations/ga4_v2/db-config.json
+++ b/src/configurations/destinations/ga4_v2/db-config.json
@@ -153,7 +153,7 @@
     "secretKeys": ["apiSecret"]
   },
   "options": {
-    "isBeta": false,
+    "isBeta": true,
     "supportsCustomMappings": true,
     "hidden": {
       "featureFlagName": "AMP_ga4_v2",


### PR DESCRIPTION
Enabling beta flag for ga4 v2