### PR TITLE
chore: skip users default true for warehouse destinations

### DIFF
--- a/src/configurations/destinations/azure_datalake/schema.json
+++ b/src/configurations/destinations/azure_datalake/schema.json
@@ -30,7 +30,7 @@
       },
       "skipUsersTable": {
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "syncFrequency": {
         "type": "string",

--- a/src/configurations/destinations/azure_datalake/ui-config.json
+++ b/src/configurations/destinations/azure_datalake/ui-config.json
@@ -150,7 +150,7 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "footerNote": "Disable the creation of a Users table. The table stores all unique users, but note that due to merge operations, it can significantly increase warehouse operation time.",
           "default": true
         },
         {

--- a/src/configurations/destinations/azure_datalake/ui-config.json
+++ b/src/configurations/destinations/azure_datalake/ui-config.json
@@ -150,8 +150,8 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Enable this feature to send event data exclusively to the Identify table, and skip user table. Eliminates the need for merge operation on the user table",
-          "default": false
+          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "default": true
         },
         {
           "type": "checkbox",

--- a/src/configurations/destinations/azure_synapse/schema.json
+++ b/src/configurations/destinations/azure_synapse/schema.json
@@ -75,7 +75,7 @@
       },
       "skipUsersTable": {
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "bucketProvider": {
         "type": "string",

--- a/src/configurations/destinations/azure_synapse/ui-config.json
+++ b/src/configurations/destinations/azure_synapse/ui-config.json
@@ -568,8 +568,8 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Enable this feature to send event data exclusively to the Identify table, and skip user table. Eliminates the need for merge operation on the user table",
-          "default": false
+          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "default": true
         },
         {
           "type": "checkbox",

--- a/src/configurations/destinations/azure_synapse/ui-config.json
+++ b/src/configurations/destinations/azure_synapse/ui-config.json
@@ -568,7 +568,7 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "footerNote": "Disable the creation of a Users table. The table stores all unique users, but note that due to merge operations, it can significantly increase warehouse operation time.",
           "default": true
         },
         {

--- a/src/configurations/destinations/bq/schema.json
+++ b/src/configurations/destinations/bq/schema.json
@@ -52,7 +52,7 @@
       },
       "skipUsersTable": {
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "excludeWindow": {
         "type": "object",

--- a/src/configurations/destinations/bq/ui-config.json
+++ b/src/configurations/destinations/bq/ui-config.json
@@ -210,7 +210,7 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "footerNote": "Disable the creation of a Users table. The table stores all unique users, but note that due to merge operations, it can significantly increase warehouse operation time.",
           "default": true
         },
         {

--- a/src/configurations/destinations/bq/ui-config.json
+++ b/src/configurations/destinations/bq/ui-config.json
@@ -210,8 +210,8 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Enable this feature to send event data exclusively to the Identify table, and skip user table. Eliminates the need for merge operation on the user table",
-          "default": false
+          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "default": true
         },
         {
           "type": "checkbox",

--- a/src/configurations/destinations/clickhouse/schema.json
+++ b/src/configurations/destinations/clickhouse/schema.json
@@ -42,7 +42,7 @@
       },
       "skipUsersTable": {
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "skipVerify": {
         "type": "boolean"

--- a/src/configurations/destinations/clickhouse/ui-config.json
+++ b/src/configurations/destinations/clickhouse/ui-config.json
@@ -576,8 +576,8 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Enable this feature to send event data exclusively to the Identify table, and skip user table. Eliminates the need for merge operation on the user table",
-          "default": false
+          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "default": true
         },
         {
           "type": "checkbox",

--- a/src/configurations/destinations/clickhouse/ui-config.json
+++ b/src/configurations/destinations/clickhouse/ui-config.json
@@ -576,7 +576,7 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "footerNote": "Disable the creation of a Users table. The table stores all unique users, but note that due to merge operations, it can significantly increase warehouse operation time.",
           "default": true
         },
         {

--- a/src/configurations/destinations/deltalake/schema.json
+++ b/src/configurations/destinations/deltalake/schema.json
@@ -34,7 +34,7 @@
       },
       "skipUsersTable": {
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "syncFrequency": {
         "type": "string",

--- a/src/configurations/destinations/deltalake/ui-config.json
+++ b/src/configurations/destinations/deltalake/ui-config.json
@@ -543,7 +543,7 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "footerNote": "Disable the creation of a Users table. The table stores all unique users, but note that due to merge operations, it can significantly increase warehouse operation time.",
           "default": true
         },
         {

--- a/src/configurations/destinations/deltalake/ui-config.json
+++ b/src/configurations/destinations/deltalake/ui-config.json
@@ -543,8 +543,8 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Enable this feature to send event data exclusively to the Identify table, and skip user table. Eliminates the need for merge operation on the user table",
-          "default": false
+          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "default": true
         },
         {
           "type": "checkbox",

--- a/src/configurations/destinations/gcs_datalake/schema.json
+++ b/src/configurations/destinations/gcs_datalake/schema.json
@@ -22,7 +22,7 @@
       },
       "skipUsersTable": {
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "tableSuffix": {
         "type": "string",

--- a/src/configurations/destinations/gcs_datalake/ui-config.json
+++ b/src/configurations/destinations/gcs_datalake/ui-config.json
@@ -157,8 +157,8 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Enable this feature to send event data exclusively to the Identify table, and skip user table. Eliminates the need for merge operation on the user table",
-          "default": false
+          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "default": true
         },
         {
           "type": "checkbox",

--- a/src/configurations/destinations/gcs_datalake/ui-config.json
+++ b/src/configurations/destinations/gcs_datalake/ui-config.json
@@ -157,7 +157,7 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "footerNote": "Disable the creation of a Users table. The table stores all unique users, but note that due to merge operations, it can significantly increase warehouse operation time.",
           "default": true
         },
         {

--- a/src/configurations/destinations/mssql/schema.json
+++ b/src/configurations/destinations/mssql/schema.json
@@ -26,7 +26,7 @@
       },
       "skipUsersTable": {
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "port": {
         "type": "string",

--- a/src/configurations/destinations/mssql/ui-config.json
+++ b/src/configurations/destinations/mssql/ui-config.json
@@ -568,8 +568,8 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Enable this feature to send event data exclusively to the Identify table, and skip user table. Eliminates the need for merge operation on the user table",
-          "default": false
+          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "default": true
         },
         {
           "type": "checkbox",

--- a/src/configurations/destinations/mssql/ui-config.json
+++ b/src/configurations/destinations/mssql/ui-config.json
@@ -568,7 +568,7 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "footerNote": "Disable the creation of a Users table. The table stores all unique users, but note that due to merge operations, it can significantly increase warehouse operation time.",
           "default": true
         },
         {

--- a/src/configurations/destinations/postgres/schema.json
+++ b/src/configurations/destinations/postgres/schema.json
@@ -39,7 +39,7 @@
       },
       "skipUsersTable": {
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "namespace": {
         "type": "string",

--- a/src/configurations/destinations/postgres/ui-config.json
+++ b/src/configurations/destinations/postgres/ui-config.json
@@ -660,7 +660,7 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "footerNote": "Disable the creation of a Users table. The table stores all unique users, but note that due to merge operations, it can significantly increase warehouse operation time.",
           "default": true
         },
         {

--- a/src/configurations/destinations/postgres/ui-config.json
+++ b/src/configurations/destinations/postgres/ui-config.json
@@ -660,8 +660,8 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Enable this feature to send event data exclusively to the Identify table, and skip user table. Eliminates the need for merge operation on the user table",
-          "default": false
+          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "default": true
         },
         {
           "type": "checkbox",

--- a/src/configurations/destinations/rs/schema.json
+++ b/src/configurations/destinations/rs/schema.json
@@ -22,7 +22,7 @@
       },
       "skipUsersTable": {
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "useSSH": {
         "type": "boolean",

--- a/src/configurations/destinations/rs/ui-config.json
+++ b/src/configurations/destinations/rs/ui-config.json
@@ -443,8 +443,8 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Enable this feature to send event data exclusively to the Identify table, and skip user table. Eliminates the need for merge operation on the user table",
-          "default": false
+          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "default": true
         },
         {
           "type": "checkbox",

--- a/src/configurations/destinations/rs/ui-config.json
+++ b/src/configurations/destinations/rs/ui-config.json
@@ -443,7 +443,7 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "footerNote": "Disable the creation of a Users table. The table stores all unique users, but note that due to merge operations, it can significantly increase warehouse operation time.",
           "default": true
         },
         {

--- a/src/configurations/destinations/s3_datalake/schema.json
+++ b/src/configurations/destinations/s3_datalake/schema.json
@@ -30,7 +30,7 @@
       },
       "skipUsersTable": {
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "enableSSE": {
         "type": "boolean",

--- a/src/configurations/destinations/s3_datalake/ui-config.json
+++ b/src/configurations/destinations/s3_datalake/ui-config.json
@@ -176,8 +176,8 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Enable this feature to send event data exclusively to the Identify table, and skip user table. Eliminates the need for merge operation on the user table",
-          "default": false
+          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "default": true
         },
         {
           "type": "checkbox",

--- a/src/configurations/destinations/s3_datalake/ui-config.json
+++ b/src/configurations/destinations/s3_datalake/ui-config.json
@@ -176,7 +176,7 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "footerNote": "Disable the creation of a Users table. The table stores all unique users, but note that due to merge operations, it can significantly increase warehouse operation time.",
           "default": true
         },
         {

--- a/src/configurations/destinations/snowflake/schema.json
+++ b/src/configurations/destinations/snowflake/schema.json
@@ -42,7 +42,7 @@
       },
       "skipUsersTable": {
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "excludeWindow": {
         "type": "object",

--- a/src/configurations/destinations/snowflake/ui-config.json
+++ b/src/configurations/destinations/snowflake/ui-config.json
@@ -591,7 +591,7 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "footerNote": "Disable the creation of a Users table. The table stores all unique users, but note that due to merge operations, it can significantly increase warehouse operation time.",
           "default": true
         },
         {

--- a/src/configurations/destinations/snowflake/ui-config.json
+++ b/src/configurations/destinations/snowflake/ui-config.json
@@ -591,8 +591,8 @@
           "type": "checkbox",
           "label": "Skip User Table",
           "value": "skipUsersTable",
-          "footerNote": "Enable this feature to send event data exclusively to the Identify table, and skip user table. Eliminates the need for merge operation on the user table",
-          "default": false
+          "footerNote": "Disable to create a Users table. The table store all unique users, but, because of merge operations, can increase warehouse operations time significantly.",
+          "default": true
         },
         {
           "type": "checkbox",


### PR DESCRIPTION
## What are the changes introduced in this PR?

- Default Skip User table to true in warehouse destination creation workflow. 

## What is the related Linear task?

- Resolves WAR-178


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
	- Changed default behavior for "Skip User Table" across multiple destinations.
	- Default value for `skipUsersTable` now set to `true`.
	- Updated footer notes explaining implications of creating a Users table and potential increases in warehouse operation time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->