### PR TITLE
feat: allow configuring of object storage files deletion for warehouse destinations

### DIFF
--- a/src/configurations/destinations/azure_datalake/db-config.json
+++ b/src/configurations/destinations/azure_datalake/db-config.json
@@ -34,6 +34,7 @@
         "syncFrequency",
         "syncStartAt",
         "underscoreDivideNumbers",
+        "cleanupObjectStorageFiles",
         "allowUsersContextTraits"
       ],
       "android": [

--- a/src/configurations/destinations/azure_datalake/schema.json
+++ b/src/configurations/destinations/azure_datalake/schema.json
@@ -40,6 +40,10 @@
       "syncStartAt": {
         "type": "string"
       },
+      "cleanupObjectStorageFiles": {
+        "type": "boolean",
+        "default": false
+      },
       "oneTrustCookieCategories": {
         "type": "object",
         "properties": {

--- a/src/configurations/destinations/azure_datalake/ui-config.json
+++ b/src/configurations/destinations/azure_datalake/ui-config.json
@@ -85,6 +85,12 @@
           "footerNote": "Use this to Grant limited access to Azure Storage resources using shared access signatures (SAS)"
         },
         {
+          "type": "checkbox",
+          "label": "Enable for cleanup of object storage files (deletion) after successful sync",
+          "value": "cleanupObjectStorageFiles",
+          "default": false
+        },
+        {
           "type": "singleSelect",
           "label": "Sync Frequency",
           "value": "syncFrequency",

--- a/src/configurations/destinations/azure_synapse/db-config.json
+++ b/src/configurations/destinations/azure_synapse/db-config.json
@@ -52,6 +52,7 @@
         "skipTracksTable",
         "skipUsersTable",
         "underscoreDivideNumbers",
+        "cleanupObjectStorageFiles",
         "allowUsersContextTraits"
       ],
       "android": [

--- a/src/configurations/destinations/azure_synapse/schema.json
+++ b/src/configurations/destinations/azure_synapse/schema.json
@@ -927,6 +927,12 @@
           "required": ["useRudderStorage"]
         },
         "then": {
+          "properties": {
+            "cleanupObjectStorageFiles": {
+              "type": "boolean",
+              "default": false
+            }
+          },
           "required": ["bucketProvider"]
         }
       },

--- a/src/configurations/destinations/azure_synapse/ui-config.json
+++ b/src/configurations/destinations/azure_synapse/ui-config.json
@@ -551,6 +551,16 @@
           "label": "Use SSL for connection",
           "value": "useSSL",
           "default": true
+        },
+        {
+          "type": "checkbox",
+          "label": "Enable for cleanup of object storage files (deletion) after successful sync",
+          "value": "cleanupObjectStorageFiles",
+          "default": false,
+          "preRequisiteField": {
+            "name": "useRudderStorage",
+            "selectedValue": false
+          }
         }
       ]
     },

--- a/src/configurations/destinations/bq/db-config.json
+++ b/src/configurations/destinations/bq/db-config.json
@@ -37,6 +37,7 @@
         "underscoreDivideNumbers",
         "allowUsersContextTraits",
         "partitionColumn",
+        "cleanupObjectStorageFiles",
         "partitionType"
       ],
       "android": [

--- a/src/configurations/destinations/bq/schema.json
+++ b/src/configurations/destinations/bq/schema.json
@@ -66,6 +66,10 @@
           }
         }
       },
+      "cleanupObjectStorageFiles": {
+        "type": "boolean",
+        "default": false
+      },
       "jsonPaths": {
         "type": "string",
         "pattern": "(^env[.].*)|.*"

--- a/src/configurations/destinations/bq/ui-config.json
+++ b/src/configurations/destinations/bq/ui-config.json
@@ -68,6 +68,12 @@
           "secret": true
         },
         {
+          "type": "checkbox",
+          "label": "Enable for cleanup of object storage files (deletion) after successful sync",
+          "value": "cleanupObjectStorageFiles",
+          "default": false
+        },
+        {
           "type": "singleSelect",
           "label": "Sync Frequency",
           "value": "syncFrequency",

--- a/src/configurations/destinations/clickhouse/db-config.json
+++ b/src/configurations/destinations/clickhouse/db-config.json
@@ -56,6 +56,7 @@
         "excludeWindow",
         "useRudderStorage",
         "underscoreDivideNumbers",
+        "cleanupObjectStorageFiles",
         "allowUsersContextTraits"
       ],
       "android": [

--- a/src/configurations/destinations/clickhouse/schema.json
+++ b/src/configurations/destinations/clickhouse/schema.json
@@ -938,6 +938,12 @@
           "required": ["useRudderStorage"]
         },
         "then": {
+          "properties": {
+            "cleanupObjectStorageFiles": {
+              "type": "boolean",
+              "default": false
+            }
+          },
           "required": ["bucketProvider"]
         }
       },

--- a/src/configurations/destinations/clickhouse/ui-config.json
+++ b/src/configurations/destinations/clickhouse/ui-config.json
@@ -559,6 +559,16 @@
           "label": "Use SSL for connection",
           "value": "useSSL",
           "default": true
+        },
+        {
+          "type": "checkbox",
+          "label": "Enable for cleanup of object storage files (deletion) after successful sync",
+          "value": "cleanupObjectStorageFiles",
+          "default": false,
+          "preRequisiteField": {
+            "name": "useRudderStorage",
+            "selectedValue": false
+          }
         }
       ]
     },

--- a/src/configurations/destinations/deltalake/db-config.json
+++ b/src/configurations/destinations/deltalake/db-config.json
@@ -53,6 +53,7 @@
         "externalLocation",
         "useRudderStorage",
         "underscoreDivideNumbers",
+        "cleanupObjectStorageFiles",
         "allowUsersContextTraits"
       ],
       "android": [

--- a/src/configurations/destinations/deltalake/schema.json
+++ b/src/configurations/destinations/deltalake/schema.json
@@ -922,6 +922,12 @@
           "required": ["useRudderStorage"]
         },
         "then": {
+          "properties": {
+            "cleanupObjectStorageFiles": {
+              "type": "boolean",
+              "default": false
+            }
+          },
           "required": ["bucketProvider"]
         }
       },

--- a/src/configurations/destinations/deltalake/ui-config.json
+++ b/src/configurations/destinations/deltalake/ui-config.json
@@ -526,6 +526,16 @@
           "required": true,
           "secret": true,
           "footerNote": "Create a service account in your GCP Project for RudderStack with roles of 'storage.objectCreator'"
+        },
+        {
+          "type": "checkbox",
+          "label": "Enable for cleanup of object storage files (deletion) after successful sync",
+          "value": "cleanupObjectStorageFiles",
+          "default": false,
+          "preRequisiteField": {
+            "name": "useRudderStorage",
+            "selectedValue": false
+          }
         }
       ]
     },

--- a/src/configurations/destinations/gcs_datalake/db-config.json
+++ b/src/configurations/destinations/gcs_datalake/db-config.json
@@ -46,6 +46,7 @@
         "skipUsersTable",
         "syncStartAt",
         "underscoreDivideNumbers",
+        "cleanupObjectStorageFiles",
         "allowUsersContextTraits"
       ],
       "android": [

--- a/src/configurations/destinations/gcs_datalake/schema.json
+++ b/src/configurations/destinations/gcs_datalake/schema.json
@@ -24,6 +24,10 @@
         "type": "boolean",
         "default": true
       },
+      "cleanupObjectStorageFiles": {
+        "type": "boolean",
+        "default": false
+      },
       "tableSuffix": {
         "type": "string",
         "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|.*"

--- a/src/configurations/destinations/gcs_datalake/ui-config.json
+++ b/src/configurations/destinations/gcs_datalake/ui-config.json
@@ -47,6 +47,12 @@
           "placeholder": "e.g: TABLE_SUFFIX_PATH"
         },
         {
+          "type": "checkbox",
+          "label": "Enable for cleanup of object storage files (deletion) after successful sync",
+          "value": "cleanupObjectStorageFiles",
+          "default": false
+        },
+        {
           "type": "singleSelect",
           "label": "Choose time window layout",
           "value": "timeWindowLayout",

--- a/src/configurations/destinations/mssql/db-config.json
+++ b/src/configurations/destinations/mssql/db-config.json
@@ -65,6 +65,7 @@
         "excludeWindow",
         "useRudderStorage",
         "underscoreDivideNumbers",
+        "cleanupObjectStorageFiles",
         "allowUsersContextTraits"
       ],
       "android": [

--- a/src/configurations/destinations/mssql/schema.json
+++ b/src/configurations/destinations/mssql/schema.json
@@ -920,6 +920,10 @@
               "type": "string",
               "enum": ["S3", "GCS", "AZURE_BLOB", "MINIO"],
               "default": "MINIO"
+            },
+            "cleanupObjectStorageFiles": {
+              "type": "boolean",
+              "default": false
             }
           },
           "required": ["bucketProvider"]

--- a/src/configurations/destinations/mssql/ui-config.json
+++ b/src/configurations/destinations/mssql/ui-config.json
@@ -551,6 +551,16 @@
           "label": "Use SSL for connection",
           "value": "useSSL",
           "default": true
+        },
+        {
+          "type": "checkbox",
+          "label": "Enable for cleanup of object storage files (deletion) after successful sync",
+          "value": "cleanupObjectStorageFiles",
+          "default": false,
+          "preRequisiteField": {
+            "name": "useRudderStorage",
+            "selectedValue": false
+          }
         }
       ]
     },

--- a/src/configurations/destinations/postgres/db-config.json
+++ b/src/configurations/destinations/postgres/db-config.json
@@ -74,6 +74,7 @@
         "clientCert",
         "serverCA",
         "underscoreDivideNumbers",
+        "cleanupObjectStorageFiles",
         "allowUsersContextTraits"
       ],
       "android": [

--- a/src/configurations/destinations/postgres/schema.json
+++ b/src/configurations/destinations/postgres/schema.json
@@ -966,6 +966,12 @@
           "required": ["useRudderStorage"]
         },
         "then": {
+          "properties": {
+            "cleanupObjectStorageFiles": {
+              "type": "boolean",
+              "default": false
+            }
+          },
           "required": ["bucketProvider"]
         }
       },

--- a/src/configurations/destinations/postgres/ui-config.json
+++ b/src/configurations/destinations/postgres/ui-config.json
@@ -643,6 +643,16 @@
           "label": "Use SSL for connection",
           "value": "useSSL",
           "default": true
+        },
+        {
+          "type": "checkbox",
+          "label": "Enable for cleanup of object storage files (deletion) after successful sync",
+          "value": "cleanupObjectStorageFiles",
+          "default": false,
+          "preRequisiteField": {
+            "name": "useRudderStorage",
+            "selectedValue": false
+          }
         }
       ]
     },

--- a/src/configurations/destinations/rs/db-config.json
+++ b/src/configurations/destinations/rs/db-config.json
@@ -68,6 +68,7 @@
         "jsonPaths",
         "useRudderStorage",
         "underscoreDivideNumbers",
+        "cleanupObjectStorageFiles",
         "allowUsersContextTraits"
       ],
       "web": [

--- a/src/configurations/destinations/rs/schema.json
+++ b/src/configurations/destinations/rs/schema.json
@@ -1014,6 +1014,10 @@
             "enableSSE": {
               "type": "boolean",
               "default": false
+            },
+            "cleanupObjectStorageFiles": {
+              "type": "boolean",
+              "default": false
             }
           },
           "required": ["bucketName"],

--- a/src/configurations/destinations/rs/ui-config.json
+++ b/src/configurations/destinations/rs/ui-config.json
@@ -426,6 +426,16 @@
             "name": "useRudderStorage",
             "selectedValue": false
           }
+        },
+        {
+          "type": "checkbox",
+          "label": "Enable for cleanup of object storage files (deletion) after successful sync",
+          "value": "cleanupObjectStorageFiles",
+          "default": false,
+          "preRequisiteField": {
+            "name": "useRudderStorage",
+            "selectedValue": false
+          }
         }
       ]
     },

--- a/src/configurations/destinations/s3_datalake/db-config.json
+++ b/src/configurations/destinations/s3_datalake/db-config.json
@@ -52,6 +52,7 @@
         "timeWindowLayout",
         "enableSSE",
         "underscoreDivideNumbers",
+        "cleanupObjectStorageFiles",
         "allowUsersContextTraits"
       ],
       "android": [

--- a/src/configurations/destinations/s3_datalake/schema.json
+++ b/src/configurations/destinations/s3_datalake/schema.json
@@ -44,6 +44,10 @@
       "syncStartAt": {
         "type": "string"
       },
+      "cleanupObjectStorageFiles": {
+        "type": "boolean",
+        "default": false
+      },
       "oneTrustCookieCategories": {
         "type": "object",
         "properties": {

--- a/src/configurations/destinations/s3_datalake/ui-config.json
+++ b/src/configurations/destinations/s3_datalake/ui-config.json
@@ -112,6 +112,16 @@
           "default": false
         },
         {
+          "type": "checkbox",
+          "label": "Enable for cleanup of object storage files (deletion) after successful sync",
+          "value": "cleanupObjectStorageFiles",
+          "default": false,
+          "preRequisiteField": {
+            "name": "useRudderStorage",
+            "selectedValue": false
+          }
+        },
+        {
           "type": "singleSelect",
           "label": "Sync Frequency",
           "value": "syncFrequency",

--- a/src/configurations/destinations/snowflake/db-config.json
+++ b/src/configurations/destinations/snowflake/db-config.json
@@ -68,6 +68,7 @@
         "privateKey",
         "privateKeyPassphrase",
         "underscoreDivideNumbers",
+        "cleanupObjectStorageFiles",
         "allowUsersContextTraits"
       ],
       "android": [

--- a/src/configurations/destinations/snowflake/schema.json
+++ b/src/configurations/destinations/snowflake/schema.json
@@ -975,6 +975,10 @@
             "prefix": {
               "type": "string",
               "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+            },
+            "cleanupObjectStorageFiles": {
+              "type": "boolean",
+              "default": false
             }
           },
           "required": ["cloudProvider"]

--- a/src/configurations/destinations/snowflake/ui-config.json
+++ b/src/configurations/destinations/snowflake/ui-config.json
@@ -574,6 +574,16 @@
           "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|.*",
           "required": true,
           "footerNote": "Create a service account in your GCP Project for RudderStack with roles of 'storage.objectCreator'"
+        },
+        {
+          "type": "checkbox",
+          "label": "Enable for cleanup of object storage files (deletion) after successful sync",
+          "value": "cleanupObjectStorageFiles",
+          "default": false,
+          "preRequisiteField": {
+            "name": "useRudderStorage",
+            "selectedValue": false
+          }
         }
       ]
     },


### PR DESCRIPTION
## What are the changes introduced in this PR?

A new boolean field is being added in this PR for all warehouse destinations which will be rendered only if user has selected their own object storage.

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option to enable cleanup of object storage files after successful sync across multiple destinations.
	- Added a toggle (checkbox) in the storage settings for each destination that lets users opt in for file cleanup (default set to off).
	- Updated the validation schema for various destinations to support the new cleanup setting, ensuring seamless configuration management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->