### PR TITLE
fix: incorrect preRequisiteField of "cleanupObjectStorageFiles" in s3 datalake

### DIFF
--- a/src/configurations/destinations/s3_datalake/ui-config.json
+++ b/src/configurations/destinations/s3_datalake/ui-config.json
@@ -115,11 +115,7 @@
           "type": "checkbox",
           "label": "Enable for cleanup of object storage files (deletion) after successful sync",
           "value": "cleanupObjectStorageFiles",
-          "default": false,
-          "preRequisiteField": {
-            "name": "useRudderStorage",
-            "selectedValue": false
-          }
+          "default": false
         },
         {
           "type": "singleSelect",


### PR DESCRIPTION
## What are the changes introduced in this PR?

Bug: There is no `useRudderStorage` config for this destination so the `cleanupObjectStorageFiles` is not showing up.

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Revised the configuration for cleaning up object storage files after synchronization, eliminating a previously required dependency. This change simplifies the interface and provides a more straightforward toggle, ensuring easier control of the cleanup process for enhanced user experience. End users will benefit from a cleaner, more intuitive configuration when managing their data lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->