### PR TITLE
fix: bigquery disable view creation option

### DIFF
--- a/src/configurations/destinations/azure_datalake/ui-config.json
+++ b/src/configurations/destinations/azure_datalake/ui-config.json
@@ -163,7 +163,7 @@
           "type": "checkbox",
           "label": "Skip Tracks Table",
           "value": "skipTracksTable",
-          "footerNote": "Enable this feature to skip sending the event data to the “tracks” table",
+          "footerNote": "Enable this toggle to skip sending the event data to the “tracks” table",
           "default": false
         }
       ]

--- a/src/configurations/destinations/azure_synapse/ui-config.json
+++ b/src/configurations/destinations/azure_synapse/ui-config.json
@@ -585,7 +585,7 @@
           "type": "checkbox",
           "label": "Skip Tracks Table",
           "value": "skipTracksTable",
-          "footerNote": "Enable this feature to skip sending the event data to the “tracks” table",
+          "footerNote": "Enable this toggle to skip sending the event data to the “tracks” table",
           "default": false
         }
       ]

--- a/src/configurations/destinations/bq/db-config.json
+++ b/src/configurations/destinations/bq/db-config.json
@@ -33,6 +33,7 @@
         "excludeWindow",
         "skipTracksTable",
         "skipUsersTable",
+        "skipViews",
         "jsonPaths",
         "underscoreDivideNumbers",
         "allowUsersContextTraits",

--- a/src/configurations/destinations/bq/schema.json
+++ b/src/configurations/destinations/bq/schema.json
@@ -50,6 +50,10 @@
         "type": "boolean",
         "default": false
       },
+      "skipViews": {
+        "type": "boolean",
+        "default": false
+      },
       "skipUsersTable": {
         "type": "boolean",
         "default": true

--- a/src/configurations/destinations/bq/ui-config.json
+++ b/src/configurations/destinations/bq/ui-config.json
@@ -223,8 +223,19 @@
           "type": "checkbox",
           "label": "Skip Tracks Table",
           "value": "skipTracksTable",
-          "footerNote": "Enable this feature to skip sending the event data to the “tracks” table",
+          "footerNote": "Enable this toggle to skip sending the event data to the “tracks” table",
           "default": false
+        },
+        {
+          "type": "checkbox",
+          "label": "Skip Views Creation",
+          "value": "skipViews",
+          "default": false,
+          "immutable": true,
+          "footerURL": {
+            "link": "https://www.rudderstack.com/docs/destinations/warehouse-destinations/bigquery/#partitioned-tables-and-views",
+            "text": "Enable this toggle to skip creation of views in BigQuery. Learn more about views"
+          }
         },
         {
           "type": "textInput",

--- a/src/configurations/destinations/clickhouse/ui-config.json
+++ b/src/configurations/destinations/clickhouse/ui-config.json
@@ -593,7 +593,7 @@
           "type": "checkbox",
           "label": "Skip Tracks Table",
           "value": "skipTracksTable",
-          "footerNote": "Enable this feature to skip sending the event data to the “tracks” table",
+          "footerNote": "Enable this toggle to skip sending the event data to the “tracks” table",
           "default": false
         }
       ]

--- a/src/configurations/destinations/deltalake/ui-config.json
+++ b/src/configurations/destinations/deltalake/ui-config.json
@@ -597,7 +597,7 @@
           "type": "checkbox",
           "label": "Skip Tracks Table",
           "value": "skipTracksTable",
-          "footerNote": "Enable this feature to skip sending the event data to the “tracks” table",
+          "footerNote": "Enable this toggle to skip sending the event data to the “tracks” table",
           "default": false
         }
       ]

--- a/src/configurations/destinations/gcs_datalake/ui-config.json
+++ b/src/configurations/destinations/gcs_datalake/ui-config.json
@@ -170,7 +170,7 @@
           "type": "checkbox",
           "label": "Skip Tracks Table",
           "value": "skipTracksTable",
-          "footerNote": "Enable this feature to skip sending the event data to the “tracks” table",
+          "footerNote": "Enable this toggle to skip sending the event data to the “tracks” table",
           "default": false
         }
       ]

--- a/src/configurations/destinations/http/db-config.json
+++ b/src/configurations/destinations/http/db-config.json
@@ -128,7 +128,6 @@
     "hidden": {
       "featureFlagName": "AMP_http_webhook",
       "featureFlagValue": false
-    },
-    "secondPositionRedirectComponent": true
+    }
   }
 }

--- a/src/configurations/destinations/mssql/ui-config.json
+++ b/src/configurations/destinations/mssql/ui-config.json
@@ -585,7 +585,7 @@
           "type": "checkbox",
           "label": "Skip Tracks Table",
           "value": "skipTracksTable",
-          "footerNote": "Enable this feature to skip sending the event data to the “tracks” table",
+          "footerNote": "Enable this toggle to skip sending the event data to the “tracks” table",
           "default": false
         }
       ]

--- a/src/configurations/destinations/postgres/ui-config.json
+++ b/src/configurations/destinations/postgres/ui-config.json
@@ -677,7 +677,7 @@
           "type": "checkbox",
           "label": "Skip Tracks Table",
           "value": "skipTracksTable",
-          "footerNote": "Enable this feature to skip sending the event data to the “tracks” table",
+          "footerNote": "Enable this toggle to skip sending the event data to the “tracks” table",
           "default": false
         },
         {

--- a/src/configurations/destinations/rs/ui-config.json
+++ b/src/configurations/destinations/rs/ui-config.json
@@ -460,7 +460,7 @@
           "type": "checkbox",
           "label": "Skip Tracks Table",
           "value": "skipTracksTable",
-          "footerNote": "Enable this feature to skip sending the event data to the “tracks” table",
+          "footerNote": "Enable this toggle to skip sending the event data to the “tracks” table",
           "default": false
         },
         {

--- a/src/configurations/destinations/s3_datalake/ui-config.json
+++ b/src/configurations/destinations/s3_datalake/ui-config.json
@@ -189,7 +189,7 @@
           "type": "checkbox",
           "label": "Skip Tracks Table",
           "value": "skipTracksTable",
-          "footerNote": "Enable this feature to skip sending the event data to the “tracks” table",
+          "footerNote": "Enable this toggle to skip sending the event data to the “tracks” table",
           "default": false
         }
       ]

--- a/src/configurations/destinations/snowflake/ui-config.json
+++ b/src/configurations/destinations/snowflake/ui-config.json
@@ -608,7 +608,7 @@
           "type": "checkbox",
           "label": "Skip Tracks Table",
           "value": "skipTracksTable",
-          "footerNote": "Enable this feature to skip sending the event data to the “tracks” table",
+          "footerNote": "Enable this toggle to skip sending the event data to the “tracks” table",
           "default": false
         },
         {

--- a/src/configurations/destinations/snowpipe_streaming/ui-config.json
+++ b/src/configurations/destinations/snowpipe_streaming/ui-config.json
@@ -85,7 +85,7 @@
           "type": "checkbox",
           "label": "Skip Tracks Table",
           "value": "skipTracksTable",
-          "footerNote": "Enable this feature to skip sending the event data to the “tracks” table",
+          "footerNote": "Enable this toggle to skip sending the event data to the “tracks” table",
           "default": false
         },
         {

--- a/test/data/validation/destinations/bq.json
+++ b/test/data/validation/destinations/bq.json
@@ -100,6 +100,40 @@
       "bucketName": "test-bucket",
       "prefix": "xyzxx",
       "namespace": "eu_new3",
+      "partitionColumn": "original_timestamp",
+      "partitionType": "hour",
+      "credentials": "{}",
+      "syncFrequency": "30",
+      "skipViews": false,
+      "testConnection": false,
+      "testConnectionTS": 1621402528550
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "project": "test-gcs-project",
+      "location": "",
+      "bucketName": "test-bucket",
+      "prefix": "xyzxx",
+      "namespace": "eu_new3",
+      "partitionColumn": "original_timestamp",
+      "partitionType": "hour",
+      "credentials": "{}",
+      "syncFrequency": "30",
+      "skipViews": true,
+      "testConnection": false,
+      "testConnectionTS": 1621402528550
+    },
+    "result": true
+  },
+  {
+    "config": {
+      "project": "test-gcs-project",
+      "location": "",
+      "bucketName": "test-bucket",
+      "prefix": "xyzxx",
+      "namespace": "eu_new3",
       "partitionColumn": "invalid",
       "partitionType": "day",
       "credentials": "{}",


### PR DESCRIPTION
## What are the changes introduced in this PR?

- Provide an option for BQ to disable the creation of views.
- For the **Skip Tracks Table** toggles footer note use `Enable this toggle` instead of `Enable this feature` for all destinations.

## What is the related Linear task?

- Resolves FR-960


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a "Skip Views" option in BigQuery configurations, allowing users to control view creation during data processing.
- **Style**
	- Updated the wording for the "Skip Tracks Table" control across multiple destinations, replacing "feature" with "toggle" for clearer user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->