### PR TITLE
chore: move sdk endpoint to destination settings section

### DIFF
--- a/src/configurations/destinations/userpilot/ui-config.json
+++ b/src/configurations/destinations/userpilot/ui-config.json
@@ -30,24 +30,6 @@
                   },
                   {
                     "type": "textInput",
-                    "label": "JS SDK ENDPOINT",
-                    "configKey": "sdkEndpoint",
-                    "regex": "^(wss?:\\/\\/)[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$",
-                    "regexErrorMessage": "Invalid SDK Endpoint URL. It should be a valid URL starting with wss:// or ws://",
-                    "placeholder": "e.g: wss://api.example.com/ws",
-                    "secret": false,
-                    "description": "Custom endpoint for the JavaScript SDK",
-                    "prerequisites": {
-                      "fields": [
-                        {
-                          "configKey": "connectionMode.web",
-                          "value": "device"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "textInput",
                     "label": "API KEY",
                     "configKey": "apiKey",
                     "regex": "^(.{0,100})$",
@@ -109,6 +91,36 @@
         "title": "Configuration settings",
         "note": "Manage the settings for your destination",
         "sections": [
+          {
+            "title": "Destination settings",
+            "note": "Configure destination-specific settings here",
+            "icon": "settings",
+            "groups": [
+              {
+                "title": "SDK Settings",
+                "fields": [
+                  {
+                    "type": "textInput",
+                    "label": "JS SDK ENDPOINT",
+                    "configKey": "sdkEndpoint",
+                    "regex": "^$|^(wss?:\\/\\/)[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$",
+                    "regexErrorMessage": "Invalid SDK Endpoint URL. It should be a valid URL starting with wss:// or ws://",
+                    "placeholder": "e.g: wss://api.example.com/ws",
+                    "secret": false,
+                    "description": "Custom endpoint for the JavaScript SDK",
+                    "prerequisites": {
+                      "fields": [
+                        {
+                          "configKey": "connectionMode.web",
+                          "value": "device"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
           {
             "id": "consentSettings",
             "title": "Consent settings",


### PR DESCRIPTION
## What are the changes introduced in this PR?

For PR https://github.com/rudderlabs/rudder-integrations-config/pull/1991

This pull request updates the `ui-config.json` file for the Userpilot destination configuration. The changes involve restructuring how the "JS SDK ENDPOINT" field is organized within the configuration, moving it into a new section for better clarity and grouping.

### Restructuring of configuration fields:

* Removed the "JS SDK ENDPOINT" field from its previous location within the configuration.
* Added a new "Destination settings" section with a "SDK Settings" group, where the "JS SDK ENDPOINT" field is now included. This reorganization improves the logical grouping of related fields and enhances the user interface.

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
