### PR TITLE
chore: gainsight_px enable datacenter for warehouse source

### DIFF
--- a/src/configurations/destinations/gainsight_px/db-config.json
+++ b/src/configurations/destinations/gainsight_px/db-config.json
@@ -115,6 +115,7 @@
         "ketchConsentPurposes"
       ],
       "warehouse": [
+        "dataCenter",
         "connectionMode",
         "consentManagement",
         "oneTrustCookieCategories",

--- a/src/configurations/destinations/gainsight_px/schema.json
+++ b/src/configurations/destinations/gainsight_px/schema.json
@@ -19,6 +19,11 @@
             "type": "string",
             "enum": ["US", "EU", "US2"],
             "default": "US"
+          },
+          "warehouse": {
+            "type": "string",
+            "enum": ["US", "EU", "US2"],
+            "default": "US"
           }
         }
       },

--- a/test/data/validation/destinations/gainsight_px.json
+++ b/test/data/validation/destinations/gainsight_px.json
@@ -50,6 +50,33 @@
     "result": true
   },
   {
+    "testTitle": "With valid destination config for warehouse",
+    "config": {
+      "apiKey": "test-host",
+      "productTagKey": "AP-XXXXXX-1",
+      "dataCenter": {
+        "web": "EU"
+      },
+      "consentManagement": {
+        "warehouse": [
+          {
+            "provider": "oneTrust",
+            "consents": [
+              {
+                "consent": "Marketing"
+              }
+            ]
+          },
+          {
+            "provider": "ketch",
+            "consents": []
+          }
+        ]
+      }
+    },
+    "result": true
+  },
+  {
     "testTitle": "With consent management custom provider config and invalid resolutionStrategy value",
     "config": {
       "apiKey": "test-host",


### PR DESCRIPTION
## What are the changes introduced in this PR?

Enable datacenter options for Gainsight_PX if the source is a warehouse

https://github.com/user-attachments/assets/4f39b2c5-2e61-4bb1-a541-238aa9ede992

## What is the related Linear task?

Resolves INT-3596

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated configuration to include "dataCenter" as a default key for the "warehouse" source type.
- **Tests**
  - Added a new test case validating multiple consent management providers for the "warehouse" source, including "dataCenter" settings.
- **New Features**
  - Added support for specifying a "warehouse" region within the data center settings, with options for US, EU, and US2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->