### PR TITLE
feat(zoho): hide region field when the account management feature flag is enabled

### DIFF
--- a/src/configurations/destinations/zoho/schema.json
+++ b/src/configurations/destinations/zoho/schema.json
@@ -2,7 +2,7 @@
   "configSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
-    "required": ["rudderAccountId", "region"],
+    "required": ["rudderAccountId"],
     "properties": {
       "region": {
         "type": "string",

--- a/src/configurations/destinations/zoho/ui-config.json
+++ b/src/configurations/destinations/zoho/ui-config.json
@@ -27,7 +27,15 @@
                         "value": "US"
                       }
                     ],
-                    "default": "US"
+                    "default": "US",
+                    "preRequisites": {
+                      "featureFlags": [
+                        {
+                          "configKey": "AMP_enable-destination-account-management-from-ui-config",
+                          "value": false
+                        }
+                      ]
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
## What are the changes introduced in this PR?

Hide region field when the account management feature flag is enabled

## What is the related Linear task?

Resolves APP-403

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The "Data Center Region" field in the Zoho destination settings now appears only when a specific feature flag is disabled, improving configurability based on feature availability.
- **Bug Fixes**
  - The Zoho destination configuration no longer requires the "region" field, simplifying setup while retaining default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->