### PR TITLE
fix: update Attentive Tag signUpSourceId pattern to allow empty strings

### DIFF
--- a/src/configurations/destinations/attentive_tag/schema.json
+++ b/src/configurations/destinations/attentive_tag/schema.json
@@ -10,7 +10,7 @@
       },
       "signUpSourceId": {
         "type": "string",
-        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^[0-9]+$"
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^[0-9]*$"
       },
       "oneTrustCookieCategories": {
         "type": "object",

--- a/test/data/validation/destinations/attentive_tag.json
+++ b/test/data/validation/destinations/attentive_tag.json
@@ -25,6 +25,12 @@
     "result": true
   },
   {
+    "config": {
+      "apiKey": "jkdhfkjdhfkjdhr38yhr3f3"
+    },
+    "result": true
+  },
+  {
     "testTitle": "With valid multiple consent management providers config",
     "config": {
       "apiKey": "jkdhfkjdhfkjdhr38yhr3f3",


### PR DESCRIPTION
## What are the changes introduced in this PR?

Updated the Attentive Tag destination configuration to allow empty strings for the signUpSourceId field and added a corresponding test case.

## What is the related Linear task?

Resolves INT-3796

## Please explain the objectives of your changes below

This change modifies the pattern validation for the signUpSourceId field to allow empty strings, which was previously only allowing non-empty numeric values.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

- Modified the signUpSourceId pattern from `^[0-9]+$` to `^[0-9]*$` to allow empty strings
- Added a new test case to validate a config with just an API key

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

Added a new test case in `test/data/validation/destinations/attentive_tag.json` to validate a config with just an API key.

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [x] Any documentation changes needed with this change?
- [x] I have executed schemaGenerator tests and updated schema if needed
- [x] Are sensitive fields marked as secret in definition config?
- [x] My test cases and placeholders use only masked/sample values for sensitive fields
- [x] Is the PR limited to 10 file changes & one task? 