### PR TITLE
feat(zoho): remove region from the zoho configs

### DIFF
--- a/src/configurations/destinations/zoho/db-config.json
+++ b/src/configurations/destinations/zoho/db-config.json
@@ -25,7 +25,7 @@
     },
     "includeKeys": ["oneTrustCookieCategories", "ketchConsentPurposes", "consentManagement"],
     "destConfig": {
-      "defaultConfig": ["rudderAccountId", "region"],
+      "defaultConfig": ["rudderAccountId"],
       "warehouse": [
         "connectionMode",
         "consentManagement",

--- a/src/configurations/destinations/zoho/schema.json
+++ b/src/configurations/destinations/zoho/schema.json
@@ -4,11 +4,6 @@
     "type": "object",
     "required": ["rudderAccountId"],
     "properties": {
-      "region": {
-        "type": "string",
-        "enum": ["US"],
-        "default": "US"
-      },
       "oneTrustCookieCategories": {
         "type": "object",
         "properties": {

--- a/src/configurations/destinations/zoho/ui-config.json
+++ b/src/configurations/destinations/zoho/ui-config.json
@@ -16,26 +16,6 @@
                     "type": "accountManagementInput",
                     "label": "Event delivery account",
                     "configKey": "rudderAccountId"
-                  },
-                  {
-                    "type": "singleSelect",
-                    "label": "Data Center Region",
-                    "configKey": "region",
-                    "options": [
-                      {
-                        "name": "US",
-                        "value": "US"
-                      }
-                    ],
-                    "default": "US",
-                    "preRequisites": {
-                      "featureFlags": [
-                        {
-                          "configKey": "AMP_enable-destination-account-management-from-ui-config",
-                          "value": false
-                        }
-                      ]
-                    }
                   }
                 ]
               }


### PR DESCRIPTION
## What are the changes introduced in this PR?

Remove region field from the zoho destination configs

## What is the related Linear task?

Resolves APP-438

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed the "Data Center Region" selection and the "region" property from Zoho destination configuration, schema, and user interface, streamlining setup to require only the "Event delivery account" input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->