### PR TITLE
chore(release): pull main into develop post release v1.120.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 1.120.0 (2025-07-21)
+
+
+### Bug Fixes
+* update fb markeing image to v8.3.19 ([#2108](https://github.com/rudderlabs/rudder-config-schema/issues/2108)) ([474a5e5](https://github.com/rudderlabs/rudder-config-schema/commit/474a5e5669580bd19610a7a8240f9e7f624f67c0))
+
+
+
 ## [1.119.0](https://github.com/rudderlabs/rudder-config-schema/compare/v1.118.1...v1.119.0) (2025-07-14)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rudder-config-schema",
-  "version": "1.119.0",
+  "version": "1.120.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rudder-config-schema",
-      "version": "1.119.0",
+      "version": "1.120.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-config-schema",
-  "version": "1.119.0",
+  "version": "1.120.0",
   "description": "",
   "main": "src/index.ts",
   "private": true,

--- a/src/configurations/sources/singer_facebook_marketing/db-config.json
+++ b/src/configurations/sources/singer_facebook_marketing/db-config.json
@@ -3,7 +3,7 @@
   "category": "singer-protocol",
   "displayName": "Facebook Ads",
   "options": {
-    "image": "rudderstack/source-facebook-marketing:v8.3.18"
+    "image": "rudderstack/source-facebook-marketing:v8.3.19"
   },
   "type": "cloudSource"
 }


### PR DESCRIPTION
Manual Back Merge PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Facebook marketing integration to use the latest image version (8.3.19), resolving an identified issue.

* **Chores**
  * Incremented the app version to 1.120.0.
  * Added a new changelog entry for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->