### PR TITLE
feat: add manual deploy workflow with verbose option

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ on:
       ref:
         type: string
         required: true
+      verbose:
+        type: boolean
+        default: false
     secrets:
       API_USERNAME:
         required: true

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -31,7 +31,26 @@ on:
         default: false
 
 jobs:
+  validate:
+    name: Validate Deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Production Deployment
+        run: |
+          if [[ "${{ inputs.deploy_url }}" == "https://api.rudderstack.com" ]]; then
+            if [[ "${{ inputs.ref }}" != "main" ]]; then
+              echo "❌ Error: Production deployments can only be made from the 'main' branch"
+              echo "Current branch: ${{ inputs.ref }}"
+              echo "Production URL: ${{ inputs.deploy_url }}"
+              exit 1
+            fi
+            echo "✅ Production deployment validation passed - deploying from main branch"
+          else
+            echo "ℹ️  Non-production deployment - branch validation skipped"
+          fi
+
   deploy:
+    needs: validate
     uses: ./.github/workflows/deploy.yml
     with:
       deploy_url: ${{ inputs.deploy_url }}

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,0 +1,42 @@
+name: Manual Deploy Configurations
+
+permissions:
+  contents: read
+  
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_url:
+        description: 'Deploy URL'
+        required: true
+        type: string
+      notify:
+        description: 'Send Slack notification'
+        required: false
+        type: boolean
+        default: true
+      version:
+        description: 'Version to deploy'
+        required: true
+        type: string
+      ref:
+        description: 'Git ref to deploy (branch/tag/commit)'
+        required: true
+        type: string
+        default: 'main'
+      verbose:
+        description: 'Enable verbose logging'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      deploy_url: ${{ inputs.deploy_url }}
+      notify: ${{ inputs.notify }}
+      version: ${{ inputs.version }}
+      ref: ${{ inputs.ref }}
+      verbose: ${{ inputs.verbose }}
+    secrets: inherit 


### PR DESCRIPTION
## What are the changes introduced in this PR?

Added a new manual deploy workflow that allows running deployments manually with optional verbose logging.

## What is the related Linear task?

Resolves INT-3962

## Please explain the objectives of your changes below

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

- Added  input parameter to deploy.yml workflow for enhanced logging
- Created new manual-deploy.yml workflow for manual triggering
- Maintained separation of concerns: deploy.yml remains reusable, manual-deploy.yml handles manual triggers

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [x] Any documentation changes needed with this change?
- [x] I have executed schemaGenerator tests and updated schema if needed
- [x] Are sensitive fields marked as secret in definition config?
- [x] My test cases and placeholders use only masked/sample values for sensitive fields
- [x] Is the PR limited to 10 file changes & one task?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a manual deployment workflow, allowing users to trigger deployments with configurable options such as deployment URL, version, git reference, notification toggle, and verbosity.
  * Added a verbosity option to deployment workflows for more detailed output when desired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->