### PR TITLE
chore: fix consent management test suite to validate legacy fields

### DIFF
--- a/src/configurations/destinations/custom_device_mode/schema.json
+++ b/src/configurations/destinations/custom_device_mode/schema.json
@@ -32,40 +32,6 @@
           }
         }
       },
-      "oneTrustCookieCategories": {
-        "type": "object",
-        "properties": {
-          "web": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "oneTrustCookieCategory": {
-                  "type": "string",
-                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
-                }
-              }
-            }
-          }
-        }
-      },
-      "ketchConsentPurposes": {
-        "type": "object",
-        "properties": {
-          "web": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "purpose": {
-                  "type": "string",
-                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
-                }
-              }
-            }
-          }
-        }
-      },
       "consentManagement": {
         "type": "object",
         "properties": {

--- a/src/configurations/destinations/custom_device_mode/schema.json
+++ b/src/configurations/destinations/custom_device_mode/schema.json
@@ -2,6 +2,7 @@
   "configSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
+    "required": [],
     "properties": {
       "eventFilteringOption": {
         "type": "string",


### PR DESCRIPTION
## What are the changes introduced in this PR?

I've updated the consent management fields integrity test suite to optionally validate the legacy consent management fields if they are already defined in the db-config.json file.

For new destinations, legacy consent fields should not be defined at all.

## What is the related Linear task?

Resolves INT-3935

## Please explain the objectives of your changes below

I've updated the validations for schema and db-config files for the legacy consent fields only if they are defined in the source specific configuration object.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
