### PR TITLE
feat: onboard validation tests for account

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,9 @@
-export * from './validator';
+import validator from './validator';
+
+export const {
+  validateConfig,
+  validateSourceDefinitions,
+  validateDestinationDefinitions,
+  validateAccountDefinitions,
+  init,
+} = validator;

--- a/src/schemas/account/account-db-config-schema.json
+++ b/src/schemas/account/account-db-config-schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "name",
+    "type",
+    "category",
+    "authenticationType",
+    "config"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[A-Z_]+$"
+    },
+    "type": {
+      "type": "string"
+    },
+    "category": {
+      "type": "string",
+      "enum": ["destination", "source"]
+    },
+    "authenticationType": {
+      "type": "string"
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "optionFields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "refreshOAuthToken": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -114,7 +114,42 @@ export async function validateSourceDefinitions(srcDefConfig: any): Promise<bool
   return true;
 }
 
+export async function validateAccountDefinitions(accDefConfig: any): Promise<boolean> {
+  const ddAjv = new Ajv({
+    allErrors: true,
+    useDefaults: true,
+    strict: true,
+    strictSchema: true,
+    strictRequired: true,
+    strictNumbers: true,
+    strictTypes: true,
+    strictTuples: true,
+  });
+
+  const validator = ddAjv.compile(
+    await importJsonFromFile(path.join(__dirname, '../schemas/account/account-db-config-schema.json')),
+  );
+
+  if (validator && !validator(accDefConfig) && validator.errors) {
+    const errorMessages: string[] = validator.errors.map((e) => {
+      const propertyName = e.instancePath.slice(1).replace(/\//g, '.');
+      return `${propertyName} ${e.message}`;
+    });
+
+    throw new Error(JSON.stringify(errorMessages));
+  }
+  return true;
+}
+
 export async function init() {
   validators = {};
   await initAjvValidators();
 }
+
+export default {
+  validateConfig,
+  validateSourceDefinitions,
+  validateDestinationDefinitions,
+  validateAccountDefinitions,
+  init,
+};

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -8,6 +8,7 @@ import {
   validateConfig,
   validateSourceDefinitions,
   validateDestinationDefinitions,
+  validateAccountDefinitions,
 } from '../src';
 
 const command = new Commander.Command();
@@ -22,6 +23,24 @@ const cmdOpts = command.opts();
 function getIntegrationNames(type: string) {
   const dirPath = path.resolve(`src/configurations/${type}`);
   return fs.readdirSync(dirPath).filter((file) => fs.statSync(`${dirPath}/${file}`).isDirectory());
+}
+
+function getAccountNames(type: string) {
+  const dirPath = path.resolve(`src/configurations/${type}`);
+  const integrations = getIntegrationNames(type);
+  const accounts: string[] = [];
+
+  integrations.forEach((integration) => {
+    const accountsPath = path.join(dirPath, integration, 'accounts');
+    if (fs.existsSync(accountsPath) && fs.statSync(accountsPath).isDirectory()) {
+      const accountNames = fs.readdirSync(accountsPath);
+      accountNames.forEach((account) => {
+        accounts.push(`${integration}/${account}`);
+      });
+    }
+  });
+
+  return accounts;
 }
 
 function getIntegrationData(name: string, type: string): Record<string, unknown>[] {
@@ -74,6 +93,16 @@ async function getSourceDefinitionConfig(srcName: string) {
   const dirPath = path.resolve(`src/configurations/sources/${srcName}`);
   const configPath = `${dirPath}/db-config.json`;
   return import(configPath);
+}
+
+async function getAccountDefinitionConfig(integrationName: string, accountName: string, type: string) {
+  const dirPath = path.resolve(`src/configurations/${type}/${integrationName}/accounts/${accountName}`);
+  if (fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
+    const accountConfig = await import(path.join(dirPath, 'db-config.json'));
+    return accountConfig.default;
+  }
+
+  throw new Error(`Account configuration not found for ${integrationName}/${accountName}`);
 }
 
 async function getDestinationDefinitionConfig(destName: string) {
@@ -319,6 +348,100 @@ describe('Source Definition validation tests', () => {
   it.each(malformedSrcDefConfigs)('$description', async (testCase) => {
     await expect(validateSourceDefinitions(testCase.input)).rejects.toThrow(
       new Error(testCase.expected),
+    );
+  });
+});
+
+describe('Account Definition validation tests', () => {
+  const destinationAccounts = getAccountNames('destinations');
+  destinationAccounts.forEach((account) => {
+    const [integration, accountName] = account.split('/');
+    it(`${integration}/${accountName} - account definition test`, async () => {
+      const accDefConfig = await getAccountDefinitionConfig(integration, accountName, 'destinations');
+      await expect(validateAccountDefinitions(accDefConfig)).resolves.toEqual(true);
+    });
+  });
+
+  const sourceAccounts = getAccountNames('sources');
+  sourceAccounts.forEach((account) => {
+    const [integration, accountName] = account.split('/');
+    it(`${integration}/${accountName} - account definition test`, async () => {
+      const accDefConfig = await getAccountDefinitionConfig(integration, accountName, 'sources');
+      await expect(validateAccountDefinitions(accDefConfig)).resolves.toEqual(true);
+    });
+  });
+
+  const malformedAccountDefConfigs = [
+    {
+      description: 'missing required properties',
+      input: {
+        config: {
+          optionFields: ['region']
+        }
+      },
+      expected: '[" must have required property \'name\'"," must have required property \'type\'"," must have required property \'category\'"," must have required property \'authenticationType\'"]'
+    },
+    {
+      description: 'invalid category',
+      input: {
+        name: 'INVALID_ACCOUNT',
+        type: 'test',
+        category: 'invalid_category',
+        authenticationType: 'oauth',
+        config: {
+          optionFields: ['region'],
+          refreshOAuthToken: true
+        }
+      },
+      expected: '["category must be equal to one of the allowed values"]'
+    },
+    {
+      description: 'invalid authentication type',
+      input: {
+        name: 'INVALID_ACCOUNT',
+        type: 'test',
+        category: 'destination',
+        authenticationType: 123,
+        config: {
+          optionFields: ['region'],
+          refreshOAuthToken: true
+        }
+      },
+      expected: '["authenticationType must be string"]'
+    },
+    {
+      description: 'invalid name format',
+      input: {
+        name: 'invalid-name',
+        type: 'test',
+        category: 'destination',
+        authenticationType: 'oauth',
+        config: {
+          optionFields: ['region'],
+          refreshOAuthToken: true
+        }
+      },
+      expected: '["name must match pattern \\\"^[A-Z_]+$\\\"\"]'
+    },
+    {
+      description: 'invalid optionFields',
+      input: {
+        name: 'INVALID_ACCOUNT',
+        type: 'test',
+        category: 'destination',
+        authenticationType: 'oauth',
+        config: {
+          optionFields: [123],
+          refreshOAuthToken: true
+        }
+      },
+      expected: '["config.optionFields.0 must be string"]'
+    }
+  ];
+
+  it.each(malformedAccountDefConfigs)('$description', async (testCase) => {
+    await expect(validateAccountDefinitions(testCase.input)).rejects.toThrow(
+      new Error(testCase.expected)
     );
   });
 });


### PR DESCRIPTION
## What are the changes introduced in this PR?

This pull request introduces functionality to validate account definitions by adding a new schema, validation logic, and corresponding tests. The most important changes include the addition of a JSON schema for account definitions, implementation of the validation logic, and comprehensive tests to ensure correctness.

### Validation logic and schema updates:
* Added a new JSON schema `account-db-config-schema.json` to define the structure and validation rules for account definitions, including required fields (`name`, `type`, `category`, `authenticationType`, `config`) and constraints on properties (e.g., `name` must match the pattern `^[A-Z_]+## What are the changes introduced in this PR?

). (`[src/schemas/account/account-db-config-schema.jsonR1-R43](diffhunk://#diff-9457f35a0a4c70122547397f59bf9affbd37b2158ce7bc91a5e6369dffb69e63R1-R43)`)
* Implemented the `validateAccountDefinitions` function in `src/validator/index.ts` to validate account configurations against the schema using `Ajv`. It throws detailed error messages for validation failures. (`[src/validator/index.tsR117-R155](diffhunk://#diff-d412fff7db4f92f840aa5d361be406981ff0eaadf1db8971ed6fc31dc38a7dbcR117-R155)`)

### Integration with the codebase:
* Updated `src/index.ts` to export the new `validateAccountDefinitions` function as part of the default `validator` object. (`[src/index.tsL1-R9](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1-R9)`)

### Testing enhancements:
* Added utility functions `getAccountNames` and `getAccountDefinitionConfig` in `test/validation.test.ts` to retrieve account configurations for testing. (`[[1]](diffhunk://#diff-e67b550a56d663358ac877465c5dd67b7d7aac829034fd6d904a660d70091a76R28-R45)`, `[[2]](diffhunk://#diff-e67b550a56d663358ac877465c5dd67b7d7aac829034fd6d904a660d70091a76R98-R107)`)
* Introduced a new test suite for account definition validation, covering both valid configurations (for source and destination accounts) and invalid configurations with detailed error expectations. (`[test/validation.test.tsR354-R447](diffhunk://#diff-e67b550a56d663358ac877465c5dd67b7d7aac829034fd6d904a660d70091a76R354-R447)`)

## What is the related Linear task?

Resolves INT-3908


### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
