### PR TITLE
chore: deprecate salesforce

### DIFF
--- a/src/configurations/destinations/salesforce/db-config.json
+++ b/src/configurations/destinations/salesforce/db-config.json
@@ -119,5 +119,9 @@
       ]
     },
     "secretKeys": ["password", "initialAccessToken"]
+  },
+  "options": {
+    "deprecated": true,
+    "deprecationLabel": "Salesforce is deprecated. Please use Salesforce V2 instead."
   }
 }


### PR DESCRIPTION
## What are the changes introduced in this PR?

This pull request introduces a deprecation notice for the Salesforce destination configuration. The main change is to inform users that the Salesforce integration is deprecated and guide them to use Salesforce V2 instead.

Deprecation update:

* Added an `options` object to `src/configurations/destinations/salesforce/db-config.json` to mark Salesforce as deprecated and display a deprecation label advising use of Salesforce V2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked the Salesforce destination as deprecated, adding a clear deprecation notice that recommends using Salesforce V2 instead. No functional changes or impact on existing setups.
* **Documentation**
  * Introduced deprecation metadata to surface a visible deprecation label in configuration-driven UIs and tooling, guiding users toward Salesforce V2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->