### PR TITLE
chore: add ignore-scripts=true to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "format": "prettier . --write",
     "lint:fix": "eslint \"src/**/*.*\" --fix",
     "lint": "npm run format && npm run lint:fix",
-    "prepare": "husky install",
     "pre-commit": "npm run pre-process && npm run test && npx lint-staged",
     "commit-msg": "commitlint --edit",
     "release:github": "DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular --config github-release.config.js",


### PR DESCRIPTION
This PR adds ignore-scripts=true to .npmrc to ensure scripts are ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Adjusted package install behavior to skip lifecycle script execution during installs in dev/CI environments.
  - Removed the automatic setup step that ran during install for developer tooling.
  - No changes to application features or user interface; end-user behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->