### PR TITLE
chore: enable additional properties in adjust schema

### DIFF
--- a/src/configurations/destinations/adj/schema.json
+++ b/src/configurations/destinations/adj/schema.json
@@ -751,6 +751,6 @@
         }
       }
     },
-    "additionalProperties": false
+    "additionalProperties": true
   }
 }


### PR DESCRIPTION
## What are the changes introduced in this PR?

This pull request makes a minor configuration update to the `adj` destination schema. The change allows the schema to accept additional properties that are not explicitly defined.

* Changed `"additionalProperties"` from `false` to `true` in `src/configurations/destinations/adj/schema.json`, enabling the schema to support extra, undefined properties.

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
