### PR TITLE
fix: gcp credentials for snowflake destination is not secret

### DIFF
--- a/src/configurations/destinations/snowflake/db-config.json
+++ b/src/configurations/destinations/snowflake/db-config.json
@@ -146,6 +146,7 @@
       "accountKey",
       "sasToken",
       "privateKey",
+      "credentials",
       "privateKeyPassphrase"
     ]
   }

--- a/src/configurations/destinations/snowflake/schema.json
+++ b/src/configurations/destinations/snowflake/schema.json
@@ -948,11 +948,11 @@
           "properties": {
             "privateKey": {
               "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|-----BEGIN (?:ENCRYPTED )?PRIVATE KEY-----[\\s\\S]+?-----END (?:ENCRYPTED )?PRIVATE KEY-----"
+              "pattern": "-----BEGIN (?:ENCRYPTED )?PRIVATE KEY-----[\\s\\S]+?-----END (?:ENCRYPTED )?PRIVATE KEY-----"
             },
             "privateKeyPassphrase": {
               "type": "string",
-              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+              "pattern": "^(.{0,100})$"
             },
             "useKeyPairAuth": {
               "const": true
@@ -1026,7 +1026,7 @@
               "properties": {
                 "accessKeyID": {
                   "type": "string",
-                  "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"
+                  "pattern": "^(.{1,100})$"
                 },
                 "accessKey": {
                   "type": "string",

--- a/src/configurations/destinations/snowflake/ui-config.json
+++ b/src/configurations/destinations/snowflake/ui-config.json
@@ -71,7 +71,7 @@
         {
           "type": "textareaInput",
           "required": true,
-          "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|-----BEGIN (?:ENCRYPTED )?PRIVATE KEY-----[\\s\\S]+?-----END (?:ENCRYPTED )?PRIVATE KEY-----",
+          "regex": "-----BEGIN (?:ENCRYPTED )?PRIVATE KEY-----[\\s\\S]+?-----END (?:ENCRYPTED )?PRIVATE KEY-----",
           "preRequisiteField": {
             "name": "useKeyPairAuth",
             "selectedValue": true
@@ -82,7 +82,7 @@
         },
         {
           "type": "textInput",
-          "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
+          "regex": "^(.{0,100})$",
           "secret": true,
           "preRequisiteField": {
             "name": "useKeyPairAuth",
@@ -426,7 +426,7 @@
           ],
           "label": "AWS Access Key ID",
           "value": "accessKeyID",
-          "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$",
+          "regex": "^(.{1,100})$",
           "regexErrorMessage": "Invalid AWS Access Key ID",
           "required": true,
           "placeholder": "e.g: access-key-id",

--- a/src/configurations/destinations/snowflake/ui-config.json
+++ b/src/configurations/destinations/snowflake/ui-config.json
@@ -71,7 +71,7 @@
         {
           "type": "textareaInput",
           "required": true,
-          "regex": "-----BEGIN (?:ENCRYPTED )?PRIVATE KEY-----[\\s\\S]+?-----END (?:ENCRYPTED )?PRIVATE KEY-----",
+          "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|-----BEGIN (?:ENCRYPTED )?PRIVATE KEY-----[\\s\\S]+?-----END (?:ENCRYPTED )?PRIVATE KEY-----",
           "preRequisiteField": {
             "name": "useKeyPairAuth",
             "selectedValue": true
@@ -82,7 +82,7 @@
         },
         {
           "type": "textInput",
-          "regex": "^(.{0,100})$",
+          "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
           "secret": true,
           "preRequisiteField": {
             "name": "useKeyPairAuth",
@@ -426,7 +426,7 @@
           ],
           "label": "AWS Access Key ID",
           "value": "accessKeyID",
-          "regex": "^(.{1,100})$",
+          "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$",
           "regexErrorMessage": "Invalid AWS Access Key ID",
           "required": true,
           "placeholder": "e.g: access-key-id",


### PR DESCRIPTION
## What are the changes introduced in this PR?

GCP credentials in snowflake destination was not being treated as secret. This PR fixes it by including the field in `secretKeys`

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a credentials configuration option for Snowflake destinations.
  - Credentials are now treated as secrets for safer handling.

- Bug Fixes
  - Strengthened validation for Snowflake settings: privateKey must be PEM-like content; privateKeyPassphrase limited to 100 characters; accessKeyID restricted to 1–100 characters.
  - Templated or environment-based placeholders are no longer accepted for these fields, preventing misconfiguration and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->