### PR TITLE
fix: add hubId preRequisites

### DIFF
--- a/src/configurations/destinations/hs/ui-config.json
+++ b/src/configurations/destinations/hs/ui-config.json
@@ -116,6 +116,24 @@
                         }
                       ]
                     }
+                  },
+                  {
+                    "type": "textInput",
+                    "label": "Hub ID",
+                    "configKey": "hubID",
+                    "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$",
+                    "regexErrorMessage": "Invalid Hub ID",
+                    "placeholder": "e.g: 74X991",
+                    "note": "Your Hub ID (under account name)",
+                    "required": true,
+                    "preRequisites": {
+                      "fields": [
+                        {
+                          "configKey": "apiVersion",
+                          "value": "legacyApi"
+                        }
+                      ]
+                    }
                   }
                 ]
               }
@@ -143,26 +161,6 @@
         "title": "Configuration settings",
         "note": "Manage the settings for your destination",
         "sections": [
-          {
-            "groups": [
-              {
-                "title": "Destination specific settings",
-                "note": "Set destination specific field values",
-                "icon": "settings",
-                "fields": [
-                  {
-                    "type": "textInput",
-                    "label": "Hub ID",
-                    "configKey": "hubID",
-                    "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$",
-                    "regexErrorMessage": "Invalid Hub ID",
-                    "placeholder": "e.g: 74X991",
-                    "note": "Your Hub ID (under account name)"
-                  }
-                ]
-              }
-            ]
-          },
           {
             "id": "consentSettings",
             "title": "Consent settings",


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0

## Write a brief explainer on your code changes.

Check linear ticket

<img width="1615" height="953" alt="image" src="https://github.com/user-attachments/assets/db09b76c-5fb2-41a5-b4a7-137c4d010818" />

## What is the related Linear task?

[Resolves INT-5951](https://linear.app/rudderstack/issue/INT-5951/hs-add-prerequisites-validation-for-hubid)

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Hub ID configuration field relocated to Connection settings section from Destination settings.
  * Hub ID is now required when using the legacy API version.
  * Stricter validation rules apply to Hub ID format to prevent configuration errors.
  * Users must provide Hub ID during setup when using legacy API connection type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->