### PR TITLE
fix: tiktok audience role for migration

### DIFF
--- a/src/configurations/destinations/tiktok_audience/db-config.json
+++ b/src/configurations/destinations/tiktok_audience/db-config.json
@@ -6,7 +6,8 @@
     "disableJsonMapper": true,
     "excludeKeys": [],
     "auth": {
-      "type": "OAuth"
+      "type": "OAuth",
+      "role": "tiktok_audience"
     },
     "includeKeys": ["oneTrustCookieCategories", "ketchConsentPurposes", "consentManagement"],
     "isAudienceSupported": true,

--- a/src/configurations/destinations/tiktok_audience/schema.json
+++ b/src/configurations/destinations/tiktok_audience/schema.json
@@ -7,6 +7,14 @@
       "rudderAccountId": {
         "type": "string"
       },
+      "isHashRequired": {
+        "type": "boolean",
+        "default": true
+      },
+      "audienceId": {
+        "type": "string",
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+      },
       "oneTrustCookieCategories": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

## What are the changes introduced in this PR?

- Add role to TikTok Audience for migration.

## What is the related Linear task?

- Resolves INT-6030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audience identifier field with pattern validation and a configurable "is hash required" flag (default: true) for TikTok Audience settings.
* **Chores**
  * Enhanced TikTok Audience authentication metadata with a dedicated role attribute to improve integration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->