### PR TITLE
feat(fb_custom_audience): replace adAccountId text input with dynamic dropdown

### DIFF
--- a/scripts/schemaGenerator.py
+++ b/scripts/schemaGenerator.py
@@ -1107,34 +1107,6 @@ def generate_schema_properties(
                                 print(
                                     f"No schema generator function found for field: {field['type']}"
                                 )
-
-                            # Determine whether this field should be added to schema "required".
-                            # A field is required if it is in the "Initial setup" template and
-                            # either has no preRequisites, or all its preRequisites use
-                            # `exists: true` and every one of those prerequisite fields is
-                            # itself already required.
-                            #
-                            # The `exists: true` distinction matters: a prereq with `value`
-                            # means the field is only shown when another field equals a specific
-                            # value (e.g. a sub-account toggle), so it is conditionally required
-                            # and must not be added to the top-level required array. A prereq
-                            # with `exists: true` means the field is shown whenever the prereq
-                            # field is present at all — so if that prereq is itself required,
-                            # this field is effectively always shown and therefore also required.
-                            #
-                            # Example: `customerId` has preRequisites on `rudderAccountId` with
-                            # `exists: true`. Since `rudderAccountId` is required, `customerId`
-                            # is always rendered and should be required too.
-                            # Contrast with `loginCustomerId`, whose prereq is
-                            # `{configKey: "subAccount", value: true}` — it is only shown when
-                            # the sub-account checkbox is checked, so it stays out of required.
-                            pre_reqs = field.get("preRequisites", {})
-                            pre_req_fields = pre_reqs.get("fields", []) if isinstance(pre_reqs, dict) else []
-                            exists_pre_req_fields = [pf for pf in pre_req_fields if pf.get("exists") is True]
-                            pre_reqs_all_required = bool(exists_pre_req_fields) and all(
-                                pf.get("configKey") in schemaObject["required"]
-                                for pf in exists_pre_req_fields
-                            )
                             if (
                                 template.get("title", "") == "Initial setup"
                                 and is_field_present_in_default_config(
@@ -1142,7 +1114,7 @@ def generate_schema_properties(
                                 )
                                 and (
                                     "preRequisites" not in field
-                                    or pre_reqs_all_required
+                                    or field.get("required", False)
                                 )
                             ):
                                 schemaObject["required"].append(field["configKey"])

--- a/scripts/schemaGenerator.py
+++ b/scripts/schemaGenerator.py
@@ -1114,7 +1114,7 @@ def generate_schema_properties(
                                 )
                                 and (
                                     "preRequisites" not in field
-                                    or field.get("required", False)
+                                    or field.get("required")
                                 )
                             ):
                                 schemaObject["required"].append(field["configKey"])

--- a/src/configurations/destinations/fb_custom_audience/ui-config.json
+++ b/src/configurations/destinations/fb_custom_audience/ui-config.json
@@ -28,20 +28,26 @@
                     "secret": true
                   },
                   {
-                    "type": "textInput",
+                    "type": "dynamicDataSelect",
                     "label": "Ad Account id",
                     "note": "Enter the Ad Account id of your business application set up",
                     "configKey": "adAccountId",
                     "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$",
-                    "regexErrorMessage": "Invalid Ad Account id",
                     "placeholder": "e.g: 2309XXX5483",
+                    "apiName": "adAccounts",
+                    "apiDependencies": ["rudderAccountId"],
                     "preRequisites": {
                       "fields": [
                         {
                           "configKey": "connectionMode.warehouse",
                           "value": "cloud"
+                        },
+                        {
+                          "configKey": "rudderAccountId",
+                          "exists": true
                         }
-                      ]
+                      ],
+                      "condition": "and"
                     }
                   },
                   {

--- a/src/configurations/destinations/google_adwords_remarketing_lists/ui-config.json
+++ b/src/configurations/destinations/google_adwords_remarketing_lists/ui-config.json
@@ -23,6 +23,7 @@
                     "note": "Select the Customer ID of your Google remarketing list",
                     "configKey": "customerId",
                     "apiName": "customerAccounts",
+                    "required": true,
                     "apiDependencies": ["rudderAccountId"],
                     "placeholder": "Select customer account",
                     "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$",


### PR DESCRIPTION
## Summary
- Replaces the `adAccountId` `textInput` field with a `dynamicDataSelect` dropdown in `fb_custom_audience/ui-config.json`
- The dropdown fetches ad accounts via the `adAccounts` API
- Gated behind `rudderAccountId` being set (requires accounts framework connection first)

Resolves [INT-5930](https://linear.app/rudderstack/issue/INT-5930)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Facebook Ad Account input replaced by a dynamic selector that pulls available ad accounts; now requires an associated account and a cloud warehouse connection to enable.
  * Google Ads Customer ID is now a required field in the setup form.

* **Bug Fixes / Validation**
  * Removed the old inline regex error message while preserving pattern validation.
  * Simplified initial-setup required-field behavior to reduce conditional requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->