### PR TITLE
fix(vuln): remediate GHA script injection

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -24,8 +24,10 @@ jobs:
 
       - name: Extract Version
         id: extract-version
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          branch_name="${{ github.event.pull_request.head.ref }}"
+          branch_name="${HEAD_REF}"
           version=${branch_name#hotfix-}
           version=${version#release/v}
 
@@ -96,10 +98,11 @@ jobs:
           gh pr create \
             --base develop \
             --head main \
-            --title "chore(release): pull main into develop post release v${{ steps.extract-version.outputs.release_version }}" \
+            --title "chore(release): pull main into develop post release v${RELEASE_VERSION}" \
             --body ":crown: *An automated PR*"
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
 
       - name: Delete Release Branch
         uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,9 @@ jobs:
           fetch-depth: 0 # Fetch all history for diff comparison
 
       - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref }}
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "${BASE_REF}"
 
       - name: Setup Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -42,8 +44,10 @@ jobs:
 
       - name: Get changed files
         id: changed_files
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }})
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}")
           echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
           echo "$CHANGED_FILES" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/validate-displayname.yml
+++ b/.github/workflows/validate-displayname.yml
@@ -24,8 +24,10 @@ jobs:
           fetch-depth: 0 # Need full history to compare with base branch
 
       - name: Fetch base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin ${{ github.base_ref }}
+          git fetch origin "${BASE_REF}"
 
       - name: Setup Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -34,5 +36,7 @@ jobs:
           cache: 'npm'
 
       - name: Validate displayName changes
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          node scripts/validateDisplayNameChanges.js --compare origin/${{ github.base_ref }}
+          node scripts/validateDisplayNameChanges.js --compare "origin/${BASE_REF}"


### PR DESCRIPTION
Replaces direct ${{ github.* }} interpolation in run: blocks with env: indirection. Prevents script injection RCE. Ref: SEC-93.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow reliability by capturing branch refs into explicit step-level environment variables, switching workflow steps to read those variables, and adding proper shell quoting when referencing branches—reducing interpolation issues and making automated release, test, and validation pipelines more robust and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->