### PR TITLE
chore: enable accounts for tiktok audience

### DIFF
--- a/src/configurations/destinations/tiktok_audience/db-config.json
+++ b/src/configurations/destinations/tiktok_audience/db-config.json
@@ -15,6 +15,9 @@
     "supportedMessageTypes": {
       "cloud": ["audiencelist", "record"]
     },
+    "supportedAccountDefinitions": {
+      "rudderAccountId": ["DESTINATION_TIKTOK_AUDIENCE_OAUTH"]
+    },
     "supportedSourceTypes": ["warehouse"],
     "supportsVisualMapper": true,
     "syncBehaviours": ["mirror"],


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

## What are the changes introduced in this PR?

- Enabled accounts for TikTok Audience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TikTok Audience destination now supports OAuth account authentication, allowing linked OAuth accounts to be used for destination configuration.
  * Added an Advertiser ID configuration option so users can specify the advertiser to target for audience operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->