### PR TITLE
chore: add migrate-to-accounts-framework skill and account schema files

### DIFF
--- a/.claude/skills/migrate-to-accounts-framework/SKILL.md
+++ b/.claude/skills/migrate-to-accounts-framework/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: migrate-to-accounts-framework
+description: Migrate a destination to the RudderStack accounts framework by adding account definitions and updating destination config, schema, UI config, and validation tests
+argument-hint: <destination-name> (e.g. "amplitude" or "mixpanel")
+---
+
+## Migrate Destination to Accounts Framework
+
+**Reference files — read all before starting:**
+- `src/schemas/account/account-db-config-schema.json` — structure and field semantics for the account `db-config.json`
+- `src/schemas/account/account-schema-schema.json` — structure for the account `schema.json` (`secretSchema` vs `optionsSchema`)
+- `src/schemas/account/account-ui-config-schema.json` — structure for the account `ui-config.json`
+- All existing account definitions under `src/configurations/destinations/*/accounts/` — read a representative sample for patterns and real examples
+
+---
+
+### Step 1: Gather context
+
+- The destination name is in `$ARGUMENTS`. If not provided, ask the user.
+- Read the destination's `db-config.json`, `ui-config.json`, and `schema.json`.
+- Identify which fields belong at the account level:
+  - **Secret fields** (`secretFields`): credentials stored encrypted — validated by `secretSchema`
+  - **Option fields** (`optionFields`): non-secret account-level config — validated by `optionsSchema`
+- Derive automatically — do not ask the user:
+  - Auth type: infer from the credential fields (see `authenticationType` description in `account-db-config-schema.json`)
+  - Account definition name: `DESTINATION_<DEST_NAME_UPPER>_<AUTH_TYPE_UPPER>`
+  - Account directory name: lowercase of the above
+  - Required/non-required: mirrors the destination's `schema.json` exactly
+  - Field labels, placeholders, notes: copy from the destination's `ui-config.json`
+
+**Ask the user only:** which fields should move to the account level (secret credential fields and non-secret option fields).
+
+Do NOT proceed until confirmed.
+
+---
+
+### Step 2: Create the account definition directory and files
+
+Create: `src/configurations/destinations/<destination>/accounts/<account_definition_name>/`
+
+Use the schema files as the source of truth for structure. Use the existing account definitions under `src/configurations/destinations/*/accounts/` as reference for real-world patterns.
+
+- **`db-config.json`** — follow `account-db-config-schema.json`; use `[]` for `optionFields` if there are none
+- **`schema.json`** — follow `account-schema-schema.json`; the `required` array in both `secretSchema` and `optionsSchema` must mirror which fields are required in the destination's `schema.json`
+- **`ui-config.json`** — follow `account-ui-config-schema.json`; copy labels, placeholders, and notes from the destination's `ui-config.json`
+
+---
+
+### Step 3: Update the destination's `db-config.json`
+
+Add `supportedAccountDefinitions` and prepend `rudderAccountId` to `destConfig.defaultConfig`:
+
+```json
+"supportedAccountDefinitions": {
+  "rudderAccountId": ["<ACCOUNT_DEFINITION_NAME>"]
+}
+```
+
+```json
+"destConfig": {
+  "defaultConfig": ["rudderAccountId", "<existing fields...>"]
+}
+```
+
+---
+
+### Step 4: Update the destination's `ui-config.json`
+
+Add `accountManagementInput` as the **first** field in the group containing the auth fields:
+
+```json
+{
+  "type": "accountManagementInput",
+  "label": "Event delivery account",
+  "configKey": "rudderAccountId"
+}
+```
+
+---
+
+### Step 5: Update the destination's `schema.json`
+
+**a)** Add `rudderAccountId` to `properties`:
+```json
+"rudderAccountId": {
+  "type": "string",
+  "pattern": "^.{1,100}$"
+}
+```
+
+**b)** Replace the top-level `"required": ["<authField>"]` with a `oneOf` mutual-exclusivity constraint (place before `allOf` if present):
+```json
+"oneOf": [
+  {
+    "required": ["<authField>"],
+    "not": { "required": ["rudderAccountId"] }
+  },
+  {
+    "required": ["rudderAccountId"],
+    "not": { "required": ["<authField>"] }
+  }
+]
+```
+
+---
+
+### Step 6: Update validation tests
+
+Append three test cases to `test/data/validation/destinations/<destination>.json` using the minimal valid config as the base:
+
+```json
+{
+  "testTitle": "Valid config with only rudderAccountId (no <authField>)",
+  "config": { "rudderAccountId": "acc123", "<other required fields>": "<values>" },
+  "result": true
+},
+{
+  "testTitle": "Invalid config with both <authField> and rudderAccountId present",
+  "config": { "<authField>": "<value>", "rudderAccountId": "acc123", "<other required fields>": "<values>" },
+  "result": false,
+  "err": [
+    " must NOT be valid",
+    " must NOT be valid",
+    " must match exactly one schema in oneOf"
+  ]
+},
+{
+  "testTitle": "Invalid config with neither <authField> nor rudderAccountId",
+  "config": { "<other required fields>": "<values>" },
+  "result": false,
+  "err": [
+    " must have required property '<authField>'",
+    " must have required property 'rudderAccountId'",
+    " must match exactly one schema in oneOf"
+  ]
+}
+```
+
+Error strings must match AJV output exactly.
+
+---
+
+### Step 7: Verify
+
+```bash
+npm test -- --testPathPattern="<destination>"
+```
+
+Fix any failures before finishing.
+
+---
+

--- a/.claude/skills/migrate-to-accounts-framework/SKILL.md
+++ b/.claude/skills/migrate-to-accounts-framework/SKILL.md
@@ -88,19 +88,21 @@ Add `accountManagementInput` as the **first** field in the group containing the 
 }
 ```
 
-**b)** Replace the top-level `"required": ["<authField>"]` with a `oneOf` mutual-exclusivity constraint (place before `allOf` if present):
+**b)** Keep existing non-auth required fields unchanged. Remove only the migrated auth fields from the top-level `required` array, then add a `oneOf` mutual-exclusivity constraint (place before `allOf` if present). If multiple auth fields are being migrated as a group, include all of them together in each branch:
 ```json
 "oneOf": [
   {
-    "required": ["<authField>"],
+    "required": ["<authField1>", "<authField2>"],
     "not": { "required": ["rudderAccountId"] }
   },
   {
     "required": ["rudderAccountId"],
-    "not": { "required": ["<authField>"] }
+    "not": { "required": ["<authField1>", "<authField2>"] }
   }
 ]
 ```
+
+For a single auth field, use `["<authField>"]` instead of the array above.
 
 ---
 

--- a/src/schemas/account/account-db-config-schema.json
+++ b/src/schemas/account/account-db-config-schema.json
@@ -5,17 +5,20 @@
   "properties": {
     "name": {
       "type": "string",
-      "pattern": "^[A-Z_]+$"
+      "pattern": "^[A-Z_]+$",
+      "description": "Unique identifier for the account definition in UPPER_SNAKE_CASE, e.g. DESTINATION_AMPLITUDE_API_KEY or DESTINATION_SALESFORCE_BULK_UPLOAD_OAUTH."
     },
     "type": {
-      "type": "string"
+      "type": "string",
+      "description": "The destination key in lowercase, e.g. amplitude or salesforce_bulk_upload."
     },
     "category": {
       "type": "string",
       "enum": ["destination", "source"]
     },
     "authenticationType": {
-      "type": "string"
+      "type": "string",
+      "description": "'oauth' is the only recognized special type — it enables platform-level OAuth flow and token refresh behavior. All other values are free-form labels that describe the credential type for the integration (e.g. 'api_key', 'access_token', 'bearer_token'). Choose a label that reflects what the user provides."
     },
     "config": {
       "type": "object",
@@ -24,21 +27,24 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
-        },
-        "refreshOAuthToken": {
-          "type": "boolean"
-        },
-        "singleAccountConstraintEnabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "If true, only one RudderStack account can be created from a single integration account identity. For example, for facebook_lead_ads_native account, we want to have a single RudderStack account from a Facebook user in a workspace."
+          },
+          "description": "Names of non-secret fields configurable at the account level (e.g. 'environment', 'region'). Note: 'option' means non-secret, not non-required — a field can be in optionFields and still be required. These are validated by optionsSchema."
         },
         "secretFields": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "Names of secret credential fields that are stored encrypted (e.g. 'accessToken', 'apiKey'). These are validated by secretSchema."
+        },
+        "refreshOAuthToken": {
+          "type": "boolean",
+          "description": "Set to true to enable automatic OAuth token refresh. Used when authenticationType is 'oauth'."
+        },
+        "singleAccountConstraintEnabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, only one RudderStack account can be created from a single integration account identity. For example, for facebook_lead_ads_native we want a single RudderStack account per Facebook user in a workspace."
         }
       },
       "additionalProperties": false

--- a/src/schemas/account/account-db-config-schema.json
+++ b/src/schemas/account/account-db-config-schema.json
@@ -5,7 +5,7 @@
   "properties": {
     "name": {
       "type": "string",
-      "pattern": "^[A-Z_]+$",
+      "pattern": "^[A-Z0-9_]+$",
       "description": "Unique identifier for the account definition in UPPER_SNAKE_CASE, e.g. DESTINATION_AMPLITUDE_API_KEY or DESTINATION_SALESFORCE_BULK_UPLOAD_OAUTH."
     },
     "type": {

--- a/src/schemas/account/account-schema-schema.json
+++ b/src/schemas/account/account-schema-schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Validates the schema.json file for an account definition. Use secretSchema for secret credential fields, optionsSchema for non-secret option fields. Both can coexist if needed.",
+  "properties": {
+    "secretSchema": {
+      "type": "object",
+      "description": "Validates secret credential fields stored encrypted (e.g. accessToken, apiKey). Note: 'optionsSchema' means non-secret, not non-required — required/non-required is independent of secret/non-secret.",
+      "required": ["$schema", "type", "properties"],
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "const": "http://json-schema.org/draft-07/schema#"
+        },
+        "required": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Fields that must be present."
+        },
+        "type": {
+          "type": "string",
+          "const": "object"
+        },
+        "properties": {
+          "type": "object",
+          "description": "Each key is a secret field name. Pattern for required fields: '(^\\{\\{.*\\|\\|(.*)\\}\\}$)|^(.{1,500})$' (min length 1). Pattern for non-required fields: '(^\\{\\{.*\\|\\|(.*)\\}\\}$)|^(.{0,200})$' (min length 0).",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["type", "pattern"],
+            "properties": {
+              "type": { "type": "string", "const": "string" },
+              "pattern": { "type": "string" }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "optionsSchema": {
+      "type": "object",
+      "description": "Validates non-secret option fields (e.g. environment, region). Always present for OAuth accounts, even if properties is empty. Can also be present alongside secretSchema for non-OAuth accounts that have non-secret option fields.",
+      "required": ["$schema", "type", "properties"],
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "const": "http://json-schema.org/draft-07/schema#"
+        },
+        "required": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Fields that must be present."
+        },
+        "type": {
+          "type": "string",
+          "const": "object"
+        },
+        "properties": {
+          "type": "object",
+          "description": "Each key is an option field name. Can be empty {} for OAuth accounts with no option fields.",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string" },
+              "enum": { "type": "array" },
+              "default": {}
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/schemas/account/account-schema-schema.json
+++ b/src/schemas/account/account-schema-schema.json
@@ -5,7 +5,7 @@
   "properties": {
     "secretSchema": {
       "type": "object",
-      "description": "Validates secret credential fields stored encrypted (e.g. accessToken, apiKey). Note: 'optionsSchema' means non-secret, not non-required — required/non-required is independent of secret/non-secret.",
+      "description": "Validates secret credential fields stored encrypted (e.g. accessToken, apiKey).",
       "required": ["$schema", "type", "properties"],
       "properties": {
         "$schema": {
@@ -38,7 +38,7 @@
     },
     "optionsSchema": {
       "type": "object",
-      "description": "Validates non-secret option fields (e.g. environment, region). Always present for OAuth accounts, even if properties is empty. Can also be present alongside secretSchema for non-OAuth accounts that have non-secret option fields.",
+      "description": "Validates non-secret option fields (e.g. environment, region). Can be present alongside secretSchema when there are non-secret option fields.",
       "required": ["$schema", "type", "properties"],
       "properties": {
         "$schema": {

--- a/src/schemas/account/account-schema-schema.json
+++ b/src/schemas/account/account-schema-schema.json
@@ -70,5 +70,9 @@
       "additionalProperties": false
     }
   },
+  "anyOf": [
+    { "required": ["secretSchema"] },
+    { "required": ["optionsSchema"] }
+  ],
   "additionalProperties": false
 }

--- a/src/schemas/account/account-ui-config-schema.json
+++ b/src/schemas/account/account-ui-config-schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Validates the ui-config.json file for an account definition.",
+  "required": ["uiConfig"],
+  "properties": {
+    "uiConfig": {
+      "type": "object",
+      "required": ["name", "icon", "description", "recommended", "form"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable auth type label shown in the UI, e.g. 'OAuth', 'API Key', 'Access Token'."
+        },
+        "icon": {
+          "type": "string",
+          "description": "Icon identifier. Use 'key' for all account types."
+        },
+        "description": {
+          "type": "string",
+          "description": "Short description of the auth method shown in the UI."
+        },
+        "recommended": {
+          "type": "boolean",
+          "description": "Whether this account type is the recommended option when multiple types exist."
+        },
+        "isOAuth": {
+          "type": "boolean",
+          "description": "Must be true for OAuth account types. Omit entirely for non-OAuth types."
+        },
+        "form": {
+          "type": "object",
+          "required": ["title", "fields"],
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Heading shown above the account creation form."
+            },
+            "fields": {
+              "type": "array",
+              "description": "Form fields. First field must always be the 'Account name' textField with key 'name'. For OAuth, only include account name and option fields — secret credential fields are handled by the OAuth flow. For non-OAuth, include account name followed by secret credential fields and any option fields.",
+              "items": {
+                "type": "object",
+                "required": ["component", "label", "key"],
+                "properties": {
+                  "component": {
+                    "type": "string",
+                    "enum": ["textField", "selectField"],
+                    "description": "Use 'textField' for free-text inputs (credentials, account name). Use 'selectField' for enumerated option fields (e.g. environment, region)."
+                  },
+                  "label": {
+                    "type": "string",
+                    "description": "Display label for the field."
+                  },
+                  "placeholder": {
+                    "type": "string",
+                    "description": "Example value shown as placeholder text."
+                  },
+                  "key": {
+                    "description": "Storage path. Use string 'name' for the account name field. Use array ['options', '<fieldKey>'] for all other fields.",
+                    "oneOf": [
+                      { "type": "string", "const": "name" },
+                      {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 2,
+                        "maxItems": 2
+                      }
+                    ]
+                  },
+                  "secret": {
+                    "type": "boolean",
+                    "description": "Set to true for secret credential fields. Omit for non-secret fields."
+                  },
+                  "optional": {
+                    "type": "boolean",
+                    "description": "Set to true for non-required fields."
+                  },
+                  "note": {
+                    "type": "string",
+                    "description": "Help text shown below the field."
+                  },
+                  "options": {
+                    "type": "array",
+                    "description": "Required for selectField. Each entry has label and value.",
+                    "items": {
+                      "type": "object",
+                      "required": ["label", "value"],
+                      "properties": {
+                        "label": { "type": "string" },
+                        "value": { "type": "string" }
+                      }
+                    }
+                  },
+                  "default": {
+                    "description": "Default value for selectField components."
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/schemas/account/account-ui-config-schema.json
+++ b/src/schemas/account/account-ui-config-schema.json
@@ -25,7 +25,7 @@
           "description": "Whether this account type is the recommended option when multiple types exist."
         },
         "isOAuth": {
-          "type": "boolean",
+          "const": true,
           "description": "Must be true for OAuth account types. Omit entirely for non-OAuth types."
         },
         "form": {
@@ -62,7 +62,11 @@
                       { "type": "string", "const": "name" },
                       {
                         "type": "array",
-                        "items": { "type": "string" },
+                        "items": [
+                          { "const": "options" },
+                          { "type": "string", "minLength": 1 }
+                        ],
+                        "additionalItems": false,
                         "minItems": 2,
                         "maxItems": 2
                       }
@@ -95,7 +99,18 @@
                   "default": {
                     "description": "Default value for selectField components."
                   }
-                }
+                },
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": { "component": { "const": "selectField" } },
+                      "required": ["component"]
+                    },
+                    "then": {
+                      "required": ["options"]
+                    }
+                  }
+                ]
               }
             }
           },

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -462,7 +462,7 @@ describe('Account Definition validation tests', () => {
           refreshOAuthToken: true,
         },
       },
-      expected: '["name must match pattern \\"^[A-Z_]+$\\""]',
+      expected: '["name must match pattern \\"^[A-Z0-9_]+$\\""]',
     },
     {
       description: 'invalid optionFields',


### PR DESCRIPTION
## Summary
- Adds `SKILL.md` to orchestrate migrating any destination to the accounts framework (account definition files, destination config/schema/UI updates, validation tests)
- Adds `account-schema-schema.json` and `account-ui-config-schema.json` as schema references for account `schema.json` and `ui-config.json` files
- Updates `account-db-config-schema.json` with field descriptions and adds `secretFields` support

## Test plan
- [ ] Run `/migrate-to-accounts-framework <destination>` against a destination not yet on the accounts framework and verify all files are generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guided migration guide for moving destinations to the accounts framework.

* **Chores**
  * Clarified human-readable descriptions in the account database configuration schema.
  * Allowed digits in UPPER_SNAKE_CASE account identifiers.
  * Added formal schemas to validate account definition and account UI configuration structures.

* **Tests**
  * Updated validation test expectations to reflect the relaxed name format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->