### PR TITLE
chore(fb_custom_audience): cleanup legacy fields post account migration

### DIFF
--- a/src/configurations/destinations/fb_custom_audience/db-config.json
+++ b/src/configurations/destinations/fb_custom_audience/db-config.json
@@ -27,8 +27,6 @@
     "destConfig": {
       "defaultConfig": [
         "rudderAccountId",
-        "accessToken",
-        "appSecret",
         "userSchema",
         "isHashRequired",
         "isRaw",
@@ -57,6 +55,6 @@
         "ketchConsentPurposes"
       ]
     },
-    "secretKeys": ["accessToken", "appSecret"]
+    "secretKeys": []
   }
 }

--- a/src/configurations/destinations/fb_custom_audience/schema.json
+++ b/src/configurations/destinations/fb_custom_audience/schema.json
@@ -2,18 +2,11 @@
   "configSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
+    "required": ["rudderAccountId"],
     "properties": {
       "rudderAccountId": {
         "type": "string",
         "pattern": "^.{1,100}$"
-      },
-      "accessToken": {
-        "type": "string",
-        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,500})$"
-      },
-      "appSecret": {
-        "type": "string",
-        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,200})$"
       },
       "userSchema": {
         "type": "array",
@@ -366,20 +359,6 @@
         }
       }
     },
-    "oneOf": [
-      {
-        "required": ["accessToken"],
-        "not": {
-          "required": ["rudderAccountId"]
-        }
-      },
-      {
-        "required": ["rudderAccountId"],
-        "not": {
-          "required": ["accessToken"]
-        }
-      }
-    ],
     "allOf": [
       {
         "if": {

--- a/src/configurations/destinations/fb_custom_audience/ui-config.json
+++ b/src/configurations/destinations/fb_custom_audience/ui-config.json
@@ -18,16 +18,6 @@
                     "configKey": "rudderAccountId"
                   },
                   {
-                    "type": "textInput",
-                    "label": "Access Token",
-                    "note": "Enter the access token of your business application set up for accessing the Facebook Marketing API.",
-                    "configKey": "accessToken",
-                    "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,500})$",
-                    "regexErrorMessage": "Invalid Access Token",
-                    "placeholder": "e.g: EAALmZAOFOFpXXXXXXPl4uSHPxQDZCrU6KbZB1gICD9y1ZBNpevRXXXXXO06WZCUuySAX7vw2Re7vmZAHo6OFFZA4vsCUqq2XqBQgkbbgXXXXXXQ4wJFJ2GXGe69qaOXgugjkdjfgRjkknkfOUUTJfmGnzShXXXXX1kDX7xZB8IX9vdfEIZBZBhHQo4ZD",
-                    "secret": true
-                  },
-                  {
                     "type": "dynamicDataSelect",
                     "label": "Ad Account id",
                     "note": "Enter the Ad Account id of your business application set up",
@@ -102,22 +92,6 @@
             "note": "Configure advanced destination-specific settings here",
             "icon": "settings",
             "groups": [
-              {
-                "title": "Event Settings",
-                "note": "Configure event-specific settings here",
-                "fields": [
-                  {
-                    "type": "textInput",
-                    "label": "App Secret",
-                    "note": "Provide App Secret from your Facebook Developer App's basic settings.",
-                    "configKey": "appSecret",
-                    "regex": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,200})$",
-                    "regexErrorMessage": "Invalid App Secret",
-                    "placeholder": "e.g: f65c45d8e013faXXXXXe1759c123456",
-                    "secret": true
-                  }
-                ]
-              },
               {
                 "title": "Destination and event level setting",
                 "note": "Configure advanced destination and event-specific settings here",

--- a/test/data/validation/destinations/fb_custom_audience.json
+++ b/test/data/validation/destinations/fb_custom_audience.json
@@ -1,7 +1,7 @@
 [
   {
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -27,7 +27,7 @@
   },
   {
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -55,7 +55,7 @@
   },
   {
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -86,7 +86,7 @@
   },
   {
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -112,35 +112,7 @@
   },
   {
     "config": {
-      "accessToken": "ABC",
-      "appSecret": "dummySecret",
-      "userSchema": [
-        "EMAIL",
-        "DOBM",
-        "DOBD",
-        "DOBY",
-        "PHONE",
-        "GEN",
-        "FI",
-        "MADID",
-        "ZIP",
-        "ST",
-        "COUNTRY"
-      ],
-      "isHashRequired": false,
-      "disableFormat": false,
-      "audienceId": "aud1",
-      "isRaw": true,
-      "type": "UNKNOWN",
-      "subType": "ANYTHING",
-      "maxUserCount": "50"
-    },
-    "result": true
-  },
-  {
-    "config": {
-      "accessToken": "ABC",
-      "appSecret": "dummySecret",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -169,8 +141,7 @@
   },
   {
     "config": {
-      "accessToken": "ABC",
-      "appSecret": "dummySecret",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -199,8 +170,7 @@
   },
   {
     "config": {
-      "accessToken": "ABC",
-      "appSecret": "dummySecret",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -229,8 +199,7 @@
   },
   {
     "config": {
-      "accessToken": "ABC",
-      "appSecret": "dummySecret",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -259,8 +228,7 @@
   },
   {
     "config": {
-      "accessToken": "",
-      "appSecret": "dummySecret",
+      "rudderAccountId": "",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -284,13 +252,13 @@
     },
     "result": false,
     "err": [
-      "accessToken must match pattern \"(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,500})$\""
+      "rudderAccountId must match pattern \"^.{1,100}$\""
     ]
   },
   {
     "testTitle": "With valid multiple consent management providers config",
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "maxUserCount": "50",
       "consentManagement": {
         "web": [
@@ -334,7 +302,7 @@
   {
     "testTitle": "With consent management custom provider config and invalid resolutionStrategy value",
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "maxUserCount": "50",
       "consentManagement": {
         "shopify": [
@@ -354,7 +322,7 @@
   {
     "testTitle": "With consent management custom provider config and no resolutionStrategy value",
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "maxUserCount": "50",
       "consentManagement": {
         "shopify": [
@@ -373,7 +341,7 @@
   {
     "testTitle": "With consent management OneTrust provider config and no resolutionStrategy value",
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "maxUserCount": "50",
       "consentManagement": {
         "shopify": [
@@ -388,7 +356,7 @@
   {
     "testTitle": "With consent management custom provider config invalid provider value",
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "maxUserCount": "50",
       "consentManagement": {
         "shopify": [
@@ -403,7 +371,7 @@
   },
   {
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -475,7 +443,7 @@
   },
   {
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -527,7 +495,7 @@
   },
   {
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -570,7 +538,7 @@
   },
   {
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -650,7 +618,7 @@
   },
   {
     "config": {
-      "accessToken": "ABC",
+      "rudderAccountId": "acc123",
       "userSchema": [
         "EMAIL",
         "DOBM",
@@ -695,33 +663,7 @@
     ]
   },
   {
-    "testTitle": "Valid config with only rudderAccountId (no accessToken)",
-    "config": {
-      "rudderAccountId": "acc123",
-      "userSchema": ["EMAIL"],
-      "isHashRequired": false,
-      "audienceId": "aud1"
-    },
-    "result": true
-  },
-  {
-    "testTitle": "Invalid config with both accessToken and rudderAccountId present",
-    "config": {
-      "accessToken": "ABC",
-      "rudderAccountId": "acc123",
-      "userSchema": ["EMAIL"],
-      "isHashRequired": false,
-      "audienceId": "aud1"
-    },
-    "result": false,
-    "err": [
-      " must NOT be valid",
-      " must NOT be valid",
-      " must match exactly one schema in oneOf"
-    ]
-  },
-  {
-    "testTitle": "Invalid config with neither accessToken nor rudderAccountId",
+    "testTitle": "Invalid config with missing rudderAccountId",
     "config": {
       "userSchema": ["EMAIL"],
       "isHashRequired": false,
@@ -729,9 +671,7 @@
     },
     "result": false,
     "err": [
-      " must have required property 'accessToken'",
-      " must have required property 'rudderAccountId'",
-      " must match exactly one schema in oneOf"
+      " must have required property 'rudderAccountId'"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- Remove `accessToken` and `appSecret` fields from schema, ui-config, and db-config following completed account migration
- Replace the `oneOf` auth constraint (allowing either `accessToken` or `rudderAccountId`) with a simple `required: ["rudderAccountId"]`
- Update all validation test cases to use `rudderAccountId` instead of `accessToken`/`appSecret`

## Test plan
- [ ] All existing validation tests pass (`npm test`)
- [ ] `fb_custom_audience` destination definition test passes
- [ ] `fb_custom_audience` schema validation test cases pass (20 TCs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)