### PR TITLE
chore: cleanup AMP_vdm-next feature flag now that it is GA

### DIFF
--- a/src/configurations/destinations/fb_custom_audience/db-config.json
+++ b/src/configurations/destinations/fb_custom_audience/db-config.json
@@ -2,7 +2,6 @@
   "name": "FB_CUSTOM_AUDIENCE",
   "displayName": "Facebook Custom Audience",
   "config": {
-    "features": ["vdm-next"],
     "supportedAccountDefinitions": {
       "rudderAccountId": ["DESTINATION_FB_CUSTOM_AUDIENCE_ACCESS_TOKEN"]
     },

--- a/src/configurations/destinations/fb_custom_audience/ui-config.json
+++ b/src/configurations/destinations/fb_custom_audience/ui-config.json
@@ -475,13 +475,6 @@
                       "configKey": "connectionMode.cloud",
                       "value": "cloud"
                     }
-                  ],
-                  "prerequisitesCondition": "or",
-                  "featureFlags": [
-                    {
-                      "configKey": "AMP_vdm-next",
-                      "value": false
-                    }
                   ]
                 }
               }

--- a/src/configurations/destinations/google_adwords_remarketing_lists/ui-config.json
+++ b/src/configurations/destinations/google_adwords_remarketing_lists/ui-config.json
@@ -224,14 +224,7 @@
                       "value": "cloud"
                     }
                   ],
-                  "condition": "or",
-                  "prerequisitesCondition": "or",
-                  "featureFlags": [
-                    {
-                      "configKey": "AMP_vdm-next",
-                      "value": false
-                    }
-                  ]
+                  "condition": "or"
                 }
               }
             ]


### PR DESCRIPTION
## Summary
- Remove `AMP_vdm-next` featureFlags prerequisite from `fb_custom_audience` and `google_adwords_remarketing_lists` ui-configs — since the flag is GA (always `true`), the `value: false` check was dead code
- Remove `vdm-next` from the `features` array in `fb_custom_audience` db-config

## Test plan
- [ ] Verify the affected destination config pages (FB Custom Audience, Google Adwords Remarketing Lists) still render correctly in the UI
- [ ] Confirm `tiktok_audience` is untouched (flag not yet GA there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated destination configuration settings for Facebook Custom Audience and Google Adwords Remarketing Lists by removing conditional feature flag entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->