### PR TITLE
docs: integration definition versioning design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ reports
 .eslintcache
 
 __pycache__
+
+.claude/memory

--- a/docs/integrations-definition-versioning/change-scenarios.md
+++ b/docs/integrations-definition-versioning/change-scenarios.md
@@ -1,0 +1,145 @@
+# Change Scenario Taxonomy
+
+## Classification Key
+
+- **Safe** = No version bump needed. Backward compatible.
+- **BREAKING** = Requires major version bump + version directory for old version + migration file.
+- **Conditional** = Breaking in some contexts, safe in others. Must check existing production data.
+
+---
+
+## schema.json Changes
+
+| #   | Change                                                | Example                                                           | Classification  | Why                                                                                                           |
+| --- | ----------------------------------------------------- | ----------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------- |
+| S1  | Add optional field                                    | Add `"region": { "type": "string" }`                              | Safe            | Old configs don't have it, new ones can. No validation failure.                                               |
+| S2  | Add required field                                    | Add `"region"` to `required` array                                | **BREAKING**    | Old configs missing this field fail validation.                                                               |
+| S3  | Remove field from properties                          | Remove `"legacyEndpoint"`                                         | **BREAKING**    | If `additionalProperties: false`, old configs with this field fail. Even with `true`, field loses validation. |
+| S4  | Rename field                                          | `restApiKey` → `apiKey`                                           | **BREAKING**    | Old configs have wrong field name. Data plane reads wrong name.                                               |
+| S5  | Change field type                                     | `"type": "string"` → `"type": "array"`                            | **BREAKING**    | Old configs have wrong type. Validation fails.                                                                |
+| S6  | Add enum value                                        | Add `"AU-01"` to dataCenter enum                                  | Safe            | Old configs still valid. New option available.                                                                |
+| S7  | Remove enum value                                     | Remove `"US-01"` from dataCenter enum                             | **Conditional** | Breaking only if existing configs use the removed value. Safe if no configs have it.                          |
+| S8  | Tighten regex                                         | `.*` → `^[a-z0-9]+$`                                              | **Conditional** | Breaking only if existing configs have values matching old regex but not new one.                             |
+| S9  | Loosen regex                                          | `^[a-z]+$` → `^[a-z0-9]+$`                                        | Safe            | All old values still match. New values also accepted.                                                         |
+| S10 | Add if-then condition                                 | If `roleBasedAuth=true`, require `iamRoleARN`                     | **Conditional** | Breaking if existing configs have `roleBasedAuth=true` without `iamRoleARN`.                                  |
+| S11 | Change default value                                  | `"default": "US-01"` → `"default": "US-03"`                       | Safe            | Only affects NEW configs. Existing configs already have explicit values.                                      |
+| S12 | Add minimum/maximum                                   | Add `"minLength": 1` to a string field                            | **Conditional** | Breaking if existing configs have empty strings for this field.                                               |
+| S13 | Change from optional to required                      | Move field into `required` array                                  | **BREAKING**    | Old configs without this field fail validation.                                                               |
+| S14 | Change from required to optional                      | Remove field from `required` array                                | Safe            | Old configs still valid. New configs can omit.                                                                |
+| S15 | Add allOf/oneOf constraint                            | Add conditional schema requiring field B when A=true              | **Conditional** | Breaking if existing configs violate the new constraint.                                                      |
+| S16 | Add `format` keyword                                  | Add `"format": "uri"` to a string field                           | **Conditional** | Breaking if existing values don't match format.                                                               |
+| S17 | Add `pattern` to array items                          | Add `"items": { "pattern": "^[A-Z]" }`                            | **Conditional** | Breaking if existing array items violate the pattern.                                                         |
+| S18 | Set `additionalProperties: false`                     | Was `true` or absent → set to `false`                             | **BREAKING**    | Old configs with extra/unknown fields fail validation.                                                        |
+| S19 | Add `minItems`/`maxItems` to array                    | Add `"minItems": 1` to an array field                             | **Conditional** | Breaking if existing configs have empty arrays for this field.                                                |
+| S20 | Change `additionalProperties` on nested object        | Nested object goes from open to closed                            | **BREAKING**    | Old configs with extra nested keys fail validation.                                                           |
+| S21 | Add `uniqueItems: true` to array                      | Array items now must be unique                                    | **Conditional** | Breaking if existing configs have duplicate items.                                                            |
+| S22 | Change `oneOf`/`anyOf` branches                       | Remove a valid branch or tighten a branch                         | **BREAKING**    | Old configs matching the removed/tightened branch fail.                                                       |
+| S23 | Restructure flat properties into nested `$ref`        | Refactor schema to use `$ref` / `definitions`                     | Safe\*          | \*Safe if the resolved schema is equivalent. Breaking if it changes validation behavior.                      |
+| S24 | Add `dependencies` / `dependentRequired`              | Field B required when field A is present                          | **Conditional** | Breaking if existing configs have A without B.                                                                |
+| S25 | Change array items type                               | `"items": { "type": "string" }` → `"items": { "type": "object" }` | **BREAKING**    | Old configs have wrong item type.                                                                             |
+| S26 | Add `not` constraint                                  | Add `"not": { "required": ["legacyField"] }`                      | **BREAKING**    | Old configs with legacyField explicitly fail.                                                                 |
+| S27 | Change property from flat to `$ref` shared definition | Inline schema → `"$ref": "#/definitions/authConfig"`              | Safe\*          | \*Safe if resolved schema is identical. Tooling that doesn't resolve `$ref` may break.                        |
+
+---
+
+## db-config.json Changes
+
+db-config.json changes that affect stored config data (destConfig, includeKeys, secretKeys) will typically have corresponding schema.json changes. The entries below focus on db-config-specific behavior that isn't already covered by the schema table.
+
+| #   | Change                                 | Example                                    | Classification  | Why                                                                                               |
+| --- | -------------------------------------- | ------------------------------------------ | --------------- | ------------------------------------------------------------------------------------------------- |
+| D1  | Add field to destConfig                | Add `"newField"` to defaultConfig array    | Safe            | New field available. No existing config affected.                                                 |
+| D2  | Move field between destConfig sections | Move from `defaultConfig` to `web` only    | **BREAKING**    | Non-web configs lose access to this field.                                                        |
+| D3  | Add/remove includeKeys or excludeKeys  | Remove `"trackingId"` from includeKeys     | **BREAKING**    | Client SDKs lose access. Device-mode integrations break.                                          |
+| D4  | Add field to secretKeys                | Add `"apiToken"` to secretKeys             | **Conditional** | If field is in includeKeys without excludeKeys → breaks. Otherwise safe.                          |
+| D5  | Add field to immutableKeys             | Add `"accountId"` to immutableKeys         | **BREAKING**    | Users can no longer edit this field on existing configs.                                          |
+| D6  | Add/remove source type                 | Remove `"unity"` from supportedSourceTypes | **BREAKING**    | Existing Unity source connections break. (Adding is safe.)                                        |
+| D7  | Add/remove connection mode             | Remove `"device"` for web                  | **BREAKING**    | Existing device-mode connections break. (Adding is safe.)                                         |
+| D8  | Change auth config                     | Add OAuth requirement                      | **BREAKING**    | Existing configs without OAuth credentials can't re-authenticate.                                 |
+| D9  | Change supportedMessageTypes           | Remove `"track"` from cloud mode           | **BREAKING**    | Existing configs expecting track events break.                                                    |
+| D10 | Change displayName                     | "Google Analytics" → "GA (Legacy)"         | **BREAKING**    | Immutable property. Requires coordinated update across all references.                            |
+| D11 | Add/change options.deprecated          | Set `deprecated: true`                     | Safe            | Informational. Existing configs continue working.                                                 |
+| D12 | Change transformAtV1 / cdkV2Enabled    | "processor" → "router"                     | Safe            | Backend internal. No config data affected.                                                        |
+| D13 | Add `hybridModeCloudEventsFilter`      | Add event filtering for hybrid mode        | **Conditional** | Safe if hybrid mode is newly added. Breaking if existing hybrid configs now have events filtered. |
+| D14 | Add/change `configFilters`             | Add field filtering rules                  | **Conditional** | Depends on what gets filtered. Could hide fields from certain clients.                            |
+
+---
+
+## ui-config.json Changes
+
+**Key principle: ui-config.json is purely a rendering layer. It NEVER directly triggers a version bump. Only the corresponding schema.json or db-config.json changes trigger versioning.**
+
+| #   | Change                                 | Example                                       | Triggers version bump? | Why                                                                                                          |
+| --- | -------------------------------------- | --------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------ |
+| U1  | Add/remove field in form               | New textInput with configKey `"newField"`     | No                     | Rendering-only. Version depends on schema.json/db-config.json changes.                                       |
+| U2  | Change field widget type               | `textInput` → `singleSelect`                  | No                     | Rendering-only. If this requires a schema type change → the schema change triggers versioning.               |
+| U3  | Change label, placeholder, description | "API Key" → "REST API Key"                    | No                     | Cosmetic.                                                                                                    |
+| U4  | Change preRequisites / conditions      | Show field only when connectionMode=cloud     | No                     | Rendering-only. API/Terraform can still send the field regardless.                                           |
+| U5  | Reorganize sections/groups/tabs        | Move field from "Setup" tab to "Advanced" tab | No                     | Rendering-only.                                                                                              |
+| U6  | Add/change regex validation            | Add `regex` to textInput field                | No                     | UI-only validation. API/Terraform use schema.json. If schema also changes → S8 triggers versioning.          |
+| U7  | Change default value                   | `"default": false` → `"default": true`        | No                     | Rendering-only default. Schema default is what matters for API/Terraform.                                    |
+| U8  | Change configKey                       | `"oldKey"` → `"newKey"`                       | **Indirectly**         | Field rename — the BREAKING trigger is the corresponding schema.json rename (S4) and db-config.json changes. |
+| U9  | Change widget to `dynamicForm`         | `textInput` → `dynamicForm`                   | **Indirectly**         | The BREAKING trigger is the schema type change (S5: string → array).                                         |
+| U10 | Change `singleSelect` → `multiSelect`  | Single value → multi value                    | **Indirectly**         | The BREAKING trigger is the schema type change (S5: string → array).                                         |
+
+---
+
+## Compound Scenarios
+
+These illustrate real-world changes that combine multiple atomic changes from above. Only scenarios that add nuance beyond the individual tables are included.
+
+> **Convention:** Version triggers are S-codes (schema) and D-codes (db-config) only. UI changes accompany but never trigger version bumps.
+
+### "Add a new required field with default"
+
+**Triggers:** S2 + S1 + D1 | **BREAKING**
+`migrate()` adds field with default value. Could be made safe by adding as optional first, then requiring in the next major.
+
+### "Change authentication from API key to OAuth"
+
+**Triggers:** D8 + S4 + D3 | **BREAKING**
+Complex — requires OAuth flow for existing users. `migrate()` renames credential fields; user must complete OAuth separately.
+
+### "Deprecate a field and add replacement"
+
+**Triggers:** S1 + D1 | **Safe** (if old field kept)
+No migration needed immediately. Old field continues working. Follow-up version removes old field → BREAKING (S3).
+
+### "Restructure flat fields into nested object"
+
+**Triggers:** S4 + S5 + D2 | **BREAKING**
+`migrate()` merges `host`, `port`, `path` into `endpoint: { url: host, port, path }`.
+
+### "Convert single-value field to multi-value"
+
+**Triggers:** S5 | **BREAKING**
+`migrate()` wraps string in array: `migrated.eventType = [config.eventType]`.
+
+### "Consolidate boolean flags into single enum"
+
+**Triggers:** S3 + S1 + S5 | **BREAKING**
+`migrate()`: `if (config.useSSL) → "ssl"`, `if (config.useProxy) → "proxy"`, else `"direct"`. Deletes old fields.
+
+### "Add conditional required field (if-then)"
+
+**Triggers:** S10 + S15 | **Conditional**
+Breaking only if existing configs have `useProxy=true` without `proxyUrl`. Check production data first.
+
+### "Move fields between destConfig source types"
+
+**Triggers:** D2 | **BREAKING**
+`trackingId` moves from `defaultConfig` (all platforms) to `web` + `android` only → iOS configs lose this field.
+
+---
+
+## Summary
+
+**Only schema.json and db-config.json changes trigger version bumps. ui-config.json never directly triggers versioning.**
+
+| Classification        | Changes                                                                                                                                                                                                                                                                                                                                |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Always Breaking**   | Remove field, rename field, change type, make optional→required, remove enum value, remove connection mode/source type, change auth, set `additionalProperties: false`, change array items type, remove `oneOf`/`anyOf` branches, add `not` constraint, change `displayName`                                                           |
+| **Never Breaking**    | Add optional field, add enum value, loosen regex, add source type/connection mode/sync behaviour, cosmetic changes (labels, placeholders, sections), change defaults, mark deprecated, change backend-internal settings, make required→optional, `$ref` refactoring                                                                    |
+| **Context-Dependent** | Tighten regex (S8), remove enum value (S7), add `format` (S16), add `pattern` to items (S17), add if-then/allOf (S10/S15), add min/max constraints (S12/S19), add `uniqueItems` (S21), add `dependencies` (S24), add to secretKeys (D4), add to immutableKeys (D5), add `hybridModeCloudEventsFilter` (D13), add `configFilters` (D14) |
+
+**Best practice for conditional changes:** Always query production configs before making the change. If any existing configs violate the new constraint, it's a major version bump.

--- a/docs/integrations-definition-versioning/schema-consolidation.md
+++ b/docs/integrations-definition-versioning/schema-consolidation.md
@@ -212,7 +212,7 @@ definition.json
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": ["dataCenter"],
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
       "restApiKey": {
         "type": "string",
@@ -360,15 +360,7 @@ definition.json
 
       "useNativeSDK": {
         "type": "object",
-        "properties": {
-          "android": { "type": "boolean" },
-          "androidKotlin": { "type": "boolean" },
-          "ios": { "type": "boolean" },
-          "iosSwift": { "type": "boolean" },
-          "web": { "type": "boolean" },
-          "reactnative": { "type": "boolean" },
-          "flutter": { "type": "boolean" }
-        },
+        "additionalProperties": { "type": "boolean" },
         "x-sourceTypeKeyed": true,
         "x-sdkVisible": true
       },
@@ -396,61 +388,25 @@ definition.json
 
       "consentManagement": {
         "type": "object",
-        "properties": {
-          "cloud": { "$ref": "#/$defs/consentArray" },
-          "warehouse": { "$ref": "#/$defs/consentArray" },
-          "android": { "$ref": "#/$defs/consentArray" },
-          "androidKotlin": { "$ref": "#/$defs/consentArray" },
-          "ios": { "$ref": "#/$defs/consentArray" },
-          "iosSwift": { "$ref": "#/$defs/consentArray" },
-          "web": { "$ref": "#/$defs/consentArray" },
-          "unity": { "$ref": "#/$defs/consentArray" },
-          "amp": { "$ref": "#/$defs/consentArray" },
-          "reactnative": { "$ref": "#/$defs/consentArray" },
-          "flutter": { "$ref": "#/$defs/consentArray" },
-          "cordova": { "$ref": "#/$defs/consentArray" },
-          "shopify": { "$ref": "#/$defs/consentArray" }
-        },
+        "additionalProperties": { "$ref": "#/$defs/consentArray" },
         "x-sourceTypeKeyed": true,
         "x-sdkVisible": true
       },
 
       "oneTrustCookieCategories": {
         "type": "object",
-        "properties": {
-          "android": { "$ref": "#/$defs/oneTrustArray" },
-          "ios": { "$ref": "#/$defs/oneTrustArray" },
-          "web": { "$ref": "#/$defs/oneTrustArray" },
-          "unity": { "$ref": "#/$defs/oneTrustArray" },
-          "amp": { "$ref": "#/$defs/oneTrustArray" },
-          "cloud": { "$ref": "#/$defs/oneTrustArray" },
-          "warehouse": { "$ref": "#/$defs/oneTrustArray" },
-          "reactnative": { "$ref": "#/$defs/oneTrustArray" },
-          "flutter": { "$ref": "#/$defs/oneTrustArray" },
-          "cordova": { "$ref": "#/$defs/oneTrustArray" },
-          "shopify": { "$ref": "#/$defs/oneTrustArray" }
-        },
+        "additionalProperties": { "$ref": "#/$defs/oneTrustArray" },
         "x-sourceTypeKeyed": true,
-        "x-sdkVisible": true
+        "x-sdkVisible": true,
+        "x-deprecated": "Use consentManagement instead. Will be removed in a future major version."
       },
 
       "ketchConsentPurposes": {
         "type": "object",
-        "properties": {
-          "android": { "$ref": "#/$defs/ketchArray" },
-          "ios": { "$ref": "#/$defs/ketchArray" },
-          "web": { "$ref": "#/$defs/ketchArray" },
-          "unity": { "$ref": "#/$defs/ketchArray" },
-          "amp": { "$ref": "#/$defs/ketchArray" },
-          "cloud": { "$ref": "#/$defs/ketchArray" },
-          "warehouse": { "$ref": "#/$defs/ketchArray" },
-          "reactnative": { "$ref": "#/$defs/ketchArray" },
-          "flutter": { "$ref": "#/$defs/ketchArray" },
-          "cordova": { "$ref": "#/$defs/ketchArray" },
-          "shopify": { "$ref": "#/$defs/ketchArray" }
-        },
+        "additionalProperties": { "$ref": "#/$defs/ketchArray" },
         "x-sourceTypeKeyed": true,
-        "x-sdkVisible": true
+        "x-sdkVisible": true,
+        "x-deprecated": "Use consentManagement instead. Will be removed in a future major version."
       }
     },
 
@@ -621,7 +577,7 @@ For contrast, here's a cloud-only destination with no source-type-keyed fields:
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": ["webhookUrl"],
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
       "webhookUrl": {
         "type": "string",
@@ -697,6 +653,7 @@ JSON Schema Draft-07 allows unknown keywords — AJV ignores them by default. We
 | `x-sdkVisible`      | `boolean` | `includeKeys` / `excludeKeys` arrays | Whether field is sent to SDK in device mode              |
 | `x-immutable`       | `boolean` | `rs-immutable` in schema             | Field cannot be changed after creation                   |
 | `x-sourceTypeKeyed` | `boolean` | `destConfig` per-source-type arrays  | Value is a source-type-keyed object (see next section)   |
+| `x-deprecated`      | `string`  | (new)                                | Deprecation message; field is scheduled for removal      |
 
 ### How consumers derive legacy arrays from annotations
 
@@ -977,3 +934,248 @@ The `config` DB column can be simplified — `destConfig`, `includeKeys`, `exclu
 3. `**connectionConfigSchema` and `connectionUIConfig`\*\* — These are newer DB columns for connection-level config (separate from destination config). They follow the same pattern and should get the same `x-` annotation treatment in a follow-up.
 4. `**$defs` and `$ref` support\*\* — Current schema.json files don't use `$ref`. The consolidated definition.json uses `$ref` to eliminate the 600+ lines of duplicated consent schema. Need to verify AJV supports this with our configuration (it does with Draft-07, but need to confirm with `useDefaults: true`).
 5. **Pre-computing vs. on-demand** — Should the config backend pre-compute `destConfig`-equivalent field lists at definition load time (once) and cache them, or compute per request? Recommendation: pre-compute at load time — it's a simple scan of properties, and definitions change rarely.
+
+---
+
+## Known Flaws in Current Implementation
+
+Issues discovered during codebase research that the consolidation should fix or explicitly acknowledge.
+
+### 1. `additionalProperties` typo — silent validation gap
+
+Two destinations (Braze, Ninetailed) have `"additonalProperties": false` (note the typo: "additonal" not "additional"). AJV ignores unknown keywords, so this has **no effect** — additional properties are silently allowed despite the apparent intent to reject them.
+
+**Zero** schema.json files across all 239 destinations correctly use `"additionalProperties": false`. This means every destination currently allows arbitrary extra properties in config data.
+
+**Impact on consolidation:** The proposal examples must use `"additionalProperties": true` (which matches current behavior) to avoid unintentionally breaking existing configs that may have extra properties. Tightening to `false` should be treated as a **separate, versioned change** per destination — not bundled into the consolidation.
+
+### 2. Consent schema duplicated 237 times
+
+`consentManagement` appears in **237** of 239 destination schemas. Each instance repeats the same sub-schema (provider, consents, resolutionStrategy, allOf conditional) once per source type — typically 13 copies. For Braze alone, the consent schema is ~600 lines of duplicated JSON.
+
+Similarly, `oneTrustCookieCategories` appears in **233** schemas, `ketchConsentPurposes` in a similar count.
+
+**No schema.json file uses `$ref` or `$defs`** — zero occurrences across the entire repo. The consolidation introduces `$defs`/`$ref` to eliminate this duplication within each file, but cross-destination shared definitions are a larger opportunity (see Future-Proofing section).
+
+### 3. `rs-immutable` is an undocumented custom keyword
+
+Only 4 destinations use `"rs-immutable": true` (BigQuery, S3 Datalake, Snowflake, Snowpipe Streaming) — all warehouse types. This is a custom JSON Schema extension without the `x-` prefix, making it inconsistent with the proposed annotation convention.
+
+**Consolidation fix:** Migrate `"rs-immutable": true` to `"x-immutable": true` for consistency. The config backend's immutability check reads this from the schema and should be updated to look for the new key.
+
+### 4. `destConfig.defaultConfig` is misleadingly named
+
+`defaultConfig` doesn't mean "default configuration values." It means "fields that apply to all source types." Every developer encountering this for the first time misreads it. The consolidation eliminates this naming issue entirely — fields without `x-sourceTypeKeyed` are implicitly global.
+
+### 5. `hidden` feature flags have inconsistent shapes
+
+48 destinations use the `hidden` option. Three different shapes exist:
+
+- `"hidden": true` (28 destinations) — always hidden
+- `"hidden": false` (11 destinations) — explicitly visible
+- `"hidden": { "featureFlagName": "AMP_ga4_v2", "featureFlagValue": false }` (9 destinations) — conditionally hidden behind a feature flag
+
+This polymorphic shape is error-prone. The consolidation should normalize this to a consistent structure in `options`.
+
+### 6. `connectionMode` enum values can diverge from `connectionModes`
+
+The top-level `connectionModes` (formerly `supportedConnectionModes`) and the `connectionMode` field in the schema declare the same enum values independently. For example:
+
+- `connectionModes.web: ["cloud", "device", "hybrid"]` (metadata)
+- `connectionMode.properties.web.enum: ["cloud", "device", "hybrid"]` (schema)
+
+If someone edits one but not the other, they diverge silently. **CI must validate** that `connectionMode.properties[sourceType].enum` matches `connectionModes[sourceType]` for every source type.
+
+---
+
+## Future-Proofing Recommendations
+
+Design decisions aimed at keeping the proposal viable for 10+ years.
+
+### 1. Source-type-keyed fields must scale with new source types
+
+**Problem:** Adding a new source type (e.g., `roku`, `visionOS`) currently requires updating the schema of every destination that has source-type-keyed fields. With `connectionMode` in 174 destinations, `consentManagement` in 237, and `oneTrustCookieCategories` in 233, that's an O(239) change for each new source type.
+
+**Solution: Use `additionalProperties` for uniform source-type-keyed fields.**
+
+Fields where every source type has the **same inner schema** (e.g., `useNativeSDK` where every source type is just `{ type: "boolean" }`) should use `additionalProperties` instead of listing each source type:
+
+```json
+"useNativeSDK": {
+  "type": "object",
+  "additionalProperties": { "type": "boolean" },
+  "x-sourceTypeKeyed": true,
+  "x-sdkVisible": true
+}
+```
+
+This validates any source type key without needing to enumerate them. Adding `roku` or `visionOS` requires zero schema changes.
+
+Fields where source types have **different inner schemas** (e.g., `connectionMode` where `web` allows `["cloud", "device", "hybrid"]` but `unity` only allows `["cloud"]`) must still use explicit `properties`. But these are the minority — most source-type-keyed fields are uniform.
+
+**Classification of current source-type-keyed fields:**
+
+| Pattern               | Fields                                                                                                              | Can use `additionalProperties`? |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| Uniform boolean       | `useNativeSDK`, `enableBrazeLogging`, `trackAnonymousUser`, `enablePushNotification`, `allowUserSuppliedJavascript` | Yes                             |
+| Uniform consent array | `consentManagement`, `oneTrustCookieCategories`, `ketchConsentPurposes`                                             | Yes                             |
+| Per-source-type enum  | `connectionMode` (different enums per source type)                                                                  | No — must list explicitly       |
+
+With this approach, adding a new source type only requires updating `connectionMode`-like fields (where enums differ per source type) and the top-level `sourceTypes`/`connectionModes` arrays. The consent and boolean fields work automatically.
+
+### 2. Shared definitions library for cross-destination reuse
+
+**Problem:** Common sub-schemas (consent management, oneTrust, ketch, event filtering) are defined independently in every destination. A bug fix or structural change must be applied 237+ times.
+
+**Solution: A `$defs` library at `src/configurations/shared/` that definitions reference via `$ref`.**
+
+```
+src/configurations/
+├── shared/
+│   └── defs/
+│       ├── consent-management.json    ← consent provider + resolution strategy
+│       ├── onetrust-categories.json   ← OneTrust cookie categories
+│       ├── ketch-purposes.json        ← Ketch consent purposes
+│       └── event-filtering.json       ← eventFilteringOption + white/blacklisted events
+├── destinations/
+│   ├── braze/
+│   │   ├── definition.json            ← references shared/$defs via $ref
+│   │   └── ui-config.json
+```
+
+Each definition.json uses `$ref` to reference shared schemas:
+
+```json
+"consentManagement": {
+  "type": "object",
+  "additionalProperties": { "$ref": "../../../shared/defs/consent-management.json" },
+  "x-sourceTypeKeyed": true
+}
+```
+
+**Trade-off:** External `$ref` requires AJV to resolve file paths. The deploy script can inline `$ref` targets before writing to the DB, keeping runtime behavior unchanged. Alternatively, we bundle shared defs at build time.
+
+### 3. `additionalProperties` policy
+
+The consolidation must establish a clear policy:
+
+| Setting             | When to use                                                      | Risk                                                                                                 |
+| ------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `true` (or omitted) | Most destinations                                                | Existing configs with extra properties continue to work. No protection against typos in field names. |
+| `false`             | Only when explicitly intended and versioned as a breaking change | Rejects unknown properties. Catches typos. But breaks any config with extra fields.                  |
+
+**Recommendation:** Default to `"additionalProperties": true` for all consolidated definitions. Tightening to `false` is a per-destination opt-in that constitutes a breaking change requiring a major version bump.
+
+### 4. Field-level deprecation
+
+Over 10 years, fields will be deprecated. Adding `x-deprecated` enables a graceful lifecycle:
+
+```json
+"oneTrustCookieCategories": {
+  "type": "object",
+  "additionalProperties": { "$ref": "#/$defs/oneTrustArray" },
+  "x-sourceTypeKeyed": true,
+  "x-sdkVisible": true,
+  "x-deprecated": "Use consentManagement instead. Will be removed in v3."
+}
+```
+
+Consumers can:
+
+- **Web app:** Show a deprecation warning in the UI next to the field
+- **CI:** Warn on PRs that add references to deprecated fields
+- **Config backend:** Log a deprecation notice when validating configs that use the field
+- **Terraform/CLI:** Show deprecation warnings in plan output
+
+The field remains in the schema (so existing configs validate), but the annotation signals intent to remove in a future major version.
+
+### 5. Connection-level config integration
+
+The config backend already has `connectionConfigSchema` and `connectionUIConfig` DB columns (added in migration `1720173455052`). Connection-level config is structurally identical to destination-level config but scoped per source-to-destination link rather than per destination.
+
+**Recommendation:** definition.json should include an optional `connectionConfig` block alongside `config`:
+
+```json
+{
+  "config": { ... },
+  "connectionConfig": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": { ... }
+  }
+}
+```
+
+This keeps connection-level schema co-located with destination-level schema in the same file. The deploy script maps `connectionConfig` to the `connectionConfigSchema` DB column, just as `config` maps to `configSchema`.
+
+Currently zero destinations use `connectionConfig` in their definitions (the DB columns exist but aren't populated from integrations-config). This is the right time to define the convention before adoption grows.
+
+### 6. Dynamic and runtime-derived configuration
+
+A small number of destinations (e.g., GA4 V2) use `configData` — a field whose value is derived from OAuth flows or external APIs at runtime, not user input. The `dynamicConfigSupported` field is defined in the config backend entity but currently unused in any destination definition.
+
+**Recommendation:** Reserve the `x-dynamic` annotation for fields whose values are runtime-derived:
+
+```json
+"configData": {
+  "type": "string",
+  "x-dynamic": true,
+  "x-sdkVisible": true
+}
+```
+
+This tells the web app not to render an input field (the value comes from OAuth), and tells the config backend to expect the value from the accounts service rather than user input. This is forward-looking — as more OAuth integrations are added, the convention is ready.
+
+### 7. Feature flag gating normalization
+
+48 destinations use `options.hidden` with inconsistent shapes. The consolidation should normalize:
+
+```json
+"options": {
+  "hidden": false,
+  "featureFlag": {
+    "name": "AMP_ga4_v2",
+    "valueWhenHidden": false
+  },
+  "isBeta": true
+}
+```
+
+Separating `hidden` (boolean) from `featureFlag` (structured object) eliminates the polymorphic type.
+
+### 8. `x-` annotation governance
+
+To prevent annotation sprawl over 10 years, the meta-schema for definition.json should define the **complete list of allowed `x-` annotations** with their types. Any undefined `x-` annotation in a definition.json fails CI validation.
+
+Current allowed set:
+
+- `x-secret` (boolean)
+- `x-sdkVisible` (boolean)
+- `x-immutable` (boolean)
+- `x-sourceTypeKeyed` (boolean)
+- `x-deprecated` (string)
+- `x-dynamic` (boolean)
+
+Adding a new `x-` annotation requires updating the meta-schema — a deliberate, reviewed change.
+
+### 9. Redundancy between `connectionModes` and `connectionMode` schema
+
+The top-level `connectionModes` declares available modes per source type. The `connectionMode` schema property declares the same enum values per source type. This is intentional (metadata vs. validation) but creates a sync risk.
+
+**Two options:**
+
+**Option A: CI validation (recommended).** Keep both, add a CI check that `connectionMode.properties[sourceType].enum === connectionModes[sourceType]` for all source types. Simple, no tooling changes.
+
+**Option B: Generate `connectionMode` schema from `connectionModes`.** The deploy script or build step auto-generates the `connectionMode` property from the top-level `connectionModes` declaration. Eliminates the redundancy but adds a generation step — which is what we're trying to remove.
+
+Recommendation: Option A. The duplication is small, the CI check is trivial, and it avoids re-introducing code generation.
+
+### 10. Schema evolution tooling
+
+Over 10 years of schema changes, teams need:
+
+1. **Schema diff tool** — Given two definition.json versions, produce a human-readable diff of what changed (new fields, removed fields, changed enums, changed defaults, changed validation rules)
+2. **Migration scaffold generator** — Given a schema diff, generate a skeleton `migrate()` function (from the versioning design) that handles the structural changes
+3. **Compatibility checker** — Given old and new schemas, automatically classify the change as safe/breaking/conditional (using the taxonomy from change-scenarios.md)
+
+These tools don't need to exist at consolidation time, but the definition.json structure should be designed to make them easy to build. Using standard JSON Schema (with well-known `x-` extensions) ensures we can leverage the JSON Schema ecosystem for diffing and validation.

--- a/docs/integrations-definition-versioning/schema-consolidation.md
+++ b/docs/integrations-definition-versioning/schema-consolidation.md
@@ -1,0 +1,979 @@
+# Schema Consolidation Proposal
+
+> This document proposes consolidating `db-config.json` + `schema.json` into a single `definition.json` per integration, while keeping `ui-config.json` separate as a rendering layer.
+> See [versioning-design.md](./versioning-design.md) for the versioning design that this consolidation supports.
+
+---
+
+## Current State: Three Files Per Destination
+
+Every destination (239 total) is defined by three files:
+
+### db-config.json — Identity + metadata + field routing
+
+```json
+{
+  "name": "BRAZE",
+  "displayName": "Braze",
+  "config": {
+    "includeKeys": ["appKey", "dataCenter", "connectionMode", ...],
+    "excludeKeys": [],
+    "secretKeys": ["restApiKey"],
+    "supportedSourceTypes": ["android", "web", "ios", ...],
+    "supportedConnectionModes": {
+      "android": ["cloud", "device", "hybrid"],
+      "web": ["cloud", "device", "hybrid"],
+      "unity": ["cloud"]
+    },
+    "supportedMessageTypes": {
+      "cloud": ["group", "identify", "track", ...],
+      "device": { "web": ["identify", "track", "page"] }
+    },
+    "destConfig": {
+      "defaultConfig": ["appKey", "dataCenter", "restApiKey", ...],
+      "web": ["useNativeSDK", "connectionMode", "trackAnonymousUser", ...],
+      "android": ["useNativeSDK", "connectionMode", ...]
+    },
+    "transformAtV1": "router",
+    "saveDestinationResponse": true,
+    "auth": { "type": "OAuth", "role": "..." },
+    "isAudienceSupported": true,
+    "throttlingCost": { "eventType": { "identify": 2, "track": 1 } },
+    "hybridModeCloudEventsFilter": { "web": { "messageType": ["identify"] } }
+  }
+}
+```
+
+### schema.json — JSON Schema for config validation
+
+```json
+{
+  "configSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["dataCenter"],
+    "properties": {
+      "dataCenter": { "type": "string", "enum": ["US-01", ...], "default": "US-01" },
+      "trackAnonymousUser": {
+        "type": "object",
+        "properties": { "web": { "type": "boolean" } }
+      },
+      "connectionMode": {
+        "type": "object",
+        "properties": {
+          "web": { "type": "string", "enum": ["cloud", "device", "hybrid"] },
+          "android": { "type": "string", "enum": ["cloud", "device", "hybrid"] }
+        }
+      }
+    },
+    "allOf": [...]
+  }
+}
+```
+
+### ui-config.json — UI rendering instructions
+
+```json
+{
+  "uiConfig": {
+    "baseTemplate": [
+      {
+        "title": "Initial setup",
+        "sections": [{
+          "groups": [{
+            "title": "Connection settings",
+            "fields": [
+              {
+                "type": "textInput",
+                "label": "Rest API Key",
+                "configKey": "restApiKey",
+                "regex": "^(.{1,100})$",
+                "placeholder": "e.g: 06c19c59-XXXX",
+                "secret": true
+              },
+              {
+                "type": "singleSelect",
+                "label": "Data Center",
+                "configKey": "dataCenter",
+                "options": [{ "label": "US-01", "value": "US-01" }, ...],
+                "default": "US-01"
+              }
+            ]
+          }]
+        }]
+      }
+    ],
+    "sdkTemplate": { ... },
+    "consentSettingsTemplate": { ... }
+  }
+}
+```
+
+### How these files reach the database
+
+`scripts/deployToDB.py` merges all three files into a flat JSON blob and stores them in the `destination_definitions` table:
+
+| DB Column      | Source                                                                     |
+| -------------- | -------------------------------------------------------------------------- |
+| `name`         | db-config.json `name`                                                      |
+| `displayName`  | db-config.json `displayName`                                               |
+| `config`       | db-config.json `config` object (includeKeys, destConfig, secretKeys, etc.) |
+| `configSchema` | schema.json `configSchema` object                                          |
+| `uiConfig`     | ui-config.json `uiConfig` object                                           |
+| `options`      | db-config.json `options` (isBeta, hidden, etc.)                            |
+| `category`     | (set separately)                                                           |
+
+The `config` column is the metadata bag — it holds field routing arrays (`destConfig`, `includeKeys`), platform capabilities (`supportedSourceTypes`, `supportedConnectionModes`), and integration behavior flags (`transformAtV1`, `auth`). The `configSchema` column holds the JSON Schema for AJV validation.
+
+### How the config backend uses these
+
+When serving config to an SDK (e.g., web JavaScript SDK):
+
+1. **Apply defaultConfig keys** — `destConfig.defaultConfig` fields are included for all source types
+2. **Apply source-type-specific keys** — `destConfig.web` fields are included for web sources
+3. **Unwrap source-type-keyed objects** — `config.trackAnonymousUser.web` → `true`
+4. **Filter by includeKeys/excludeKeys** — only `includeKeys` fields are sent to the SDK
+5. **Extract secrets** — `secretKeys` fields are stored separately in the secrets service
+
+The critical unwrapping code in `sourceConfig.service.ts`:
+
+```typescript
+destConfig[sourceType].forEach((configKey) => {
+  if (originalConfig[configKey]?.[sourceType] !== undefined) {
+    set(filteredConfig, configKey, originalConfig[configKey][sourceType]);
+  }
+});
+```
+
+---
+
+## Problems With The Current System
+
+1. **Same field described in multiple places** — A field's name is in db-config (`destConfig`, `includeKeys`, `secretKeys`), its type and validation are in schema.json, and its rendering is in ui-config.json. Three files, three sources of "truth."
+2. **Redundant declarations** — `enum` values appear in both schema.json and ui-config.json (`options` array). `default` values appear in both. `regex` patterns appear in both. `secret` status is in both db-config (`secretKeys`) and ui-config (`secret: true`).
+3. **Top-level arrays drift from reality** — `includeKeys`, `secretKeys`, `excludeKeys` are manually maintained lists that can go out of sync with the actual properties in schema.json. Adding a field to the schema but forgetting `includeKeys` means the SDK never sees it.
+4. `**destConfig` duplicates schema structure\*\* — `destConfig.web: ["trackAnonymousUser"]` is redundant information when the schema already has `trackAnonymousUser.properties.web`. The schemaGenerator.py generates the source-type-keyed schema from destConfig, but the reverse derivation is equally trivial.
+5. `**schemaGenerator.py` bridges the gap\*\* — This 1200-line script exists solely because db-config and schema are separate files. It reads ui-config field types + db-config `destConfig` to generate schema.json. Consolidation eliminates it.
+6. **Adding a field requires 2-3 file edits** — Add to schema.json properties, add to db-config `destConfig` (and possibly `includeKeys`, `secretKeys`), add to ui-config for rendering.
+
+---
+
+## Design Principles
+
+1. **JSON Schema as the backbone** — The `config` block in definition.json IS a valid JSON Schema Draft-07 document. AJV validates config data against it directly. No separate schema.json generation.
+2. `**x-` prefixed annotations replace top-level arrays\*\* — JSON Schema allows vendor extensions prefixed with `x-`. AJV ignores them by default. Field annotations like `x-secret`, `x-sdkVisible`, `x-sourceTypeKeyed` live on the field itself.
+3. `**x-sourceTypeKeyed` replaces `destConfig`\*\* — A boolean annotation that tells consumers "this field's value is a source-type-keyed object; unwrap it per source type." The schema properties encode which source types.
+4. **ui-config.json stays separate** — It is purely a rendering concern. The _shape_ of config it produces (field names, types, enums, defaults) must come from definition.json, not be independently declared.
+5. **Config data schema unchanged** — Stored config payloads (`{ "restApiKey": "xxx", "trackAnonymousUser": { "web": true } }`) remain identical. This consolidation only changes how definitions are _authored and maintained_.
+
+---
+
+## definition.json Structure
+
+### Top-Level Anatomy
+
+```
+definition.json
+├── $schema                           ← meta-schema reference
+├── name, displayName                 ← identity (DB columns)
+├── configVersion                     ← version metadata
+│
+├── config                            ← JSON Schema Draft-07 (replaces schema.json)
+│   ├── $schema, type, required
+│   ├── properties                    ← field definitions with x- annotations
+│   └── allOf                         ← conditional validation (if/then)
+│
+├── sourceTypes                       ← replaces config.supportedSourceTypes
+├── connectionModes                   ← replaces config.supportedConnectionModes
+├── messageTypes                      ← replaces config.supportedMessageTypes
+│
+├── transformAtV1                     ← integration behavior
+├── saveDestinationResponse
+├── auth
+│
+├── isAudienceSupported?              ← optional capabilities
+├── supportsVisualMapper?
+├── throttlingCost?
+├── hybridModeCloudEventsFilter?
+└── options?                          ← isBeta, hidden, etc.
+```
+
+### Complete Braze Example
+
+```json
+{
+  "$schema": "https://rudderstack.com/schemas/destination-definition/v1",
+
+  "name": "BRAZE",
+  "displayName": "Braze",
+  "configVersion": { "version": "1.0", "status": "current" },
+
+  "config": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["dataCenter"],
+    "additionalProperties": false,
+    "properties": {
+      "restApiKey": {
+        "type": "string",
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$",
+        "x-secret": true,
+        "x-sdkVisible": false
+      },
+
+      "appKey": {
+        "type": "string",
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$",
+        "x-secret": true,
+        "x-sdkVisible": true
+      },
+
+      "dataCenter": {
+        "type": "string",
+        "enum": [
+          "US-01",
+          "US-02",
+          "US-03",
+          "US-04",
+          "US-05",
+          "US-06",
+          "US-07",
+          "US-08",
+          "EU-01",
+          "EU-02",
+          "EU-03",
+          "AU-01"
+        ],
+        "default": "US-01",
+        "x-sdkVisible": true
+      },
+
+      "usePlatformSpecificApiKeys": {
+        "type": "boolean"
+      },
+
+      "androidApiKey": {
+        "type": "string",
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"
+      },
+
+      "iOSApiKey": {
+        "type": "string",
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"
+      },
+
+      "webApiKey": {
+        "type": "string",
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"
+      },
+
+      "enableSubscriptionGroupInGroupCall": {
+        "type": "boolean",
+        "default": false
+      },
+
+      "enableNestedArrayOperations": {
+        "type": "boolean",
+        "default": false
+      },
+
+      "sendPurchaseEventWithExtraProperties": {
+        "type": "boolean",
+        "default": false
+      },
+
+      "supportDedup": {
+        "type": "boolean",
+        "default": false
+      },
+
+      "eventFilteringOption": {
+        "type": "string",
+        "enum": ["disable", "whitelistedEvents", "blacklistedEvents"],
+        "default": "disable",
+        "x-sdkVisible": true
+      },
+
+      "whitelistedEvents": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "eventName": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+            }
+          }
+        },
+        "x-sdkVisible": true
+      },
+
+      "blacklistedEvents": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "eventName": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+            }
+          }
+        },
+        "x-sdkVisible": true
+      },
+
+      "trackAnonymousUser": {
+        "type": "object",
+        "properties": {
+          "web": { "type": "boolean" }
+        },
+        "x-sourceTypeKeyed": true,
+        "x-sdkVisible": true
+      },
+
+      "enableBrazeLogging": {
+        "type": "object",
+        "properties": {
+          "web": { "type": "boolean" }
+        },
+        "x-sourceTypeKeyed": true,
+        "x-sdkVisible": true
+      },
+
+      "enablePushNotification": {
+        "type": "object",
+        "properties": {
+          "web": { "type": "boolean" }
+        },
+        "x-sourceTypeKeyed": true,
+        "x-sdkVisible": true
+      },
+
+      "allowUserSuppliedJavascript": {
+        "type": "object",
+        "properties": {
+          "web": { "type": "boolean" }
+        },
+        "x-sourceTypeKeyed": true,
+        "x-sdkVisible": true
+      },
+
+      "useNativeSDK": {
+        "type": "object",
+        "properties": {
+          "android": { "type": "boolean" },
+          "androidKotlin": { "type": "boolean" },
+          "ios": { "type": "boolean" },
+          "iosSwift": { "type": "boolean" },
+          "web": { "type": "boolean" },
+          "reactnative": { "type": "boolean" },
+          "flutter": { "type": "boolean" }
+        },
+        "x-sourceTypeKeyed": true,
+        "x-sdkVisible": true
+      },
+
+      "connectionMode": {
+        "type": "object",
+        "properties": {
+          "android": { "type": "string", "enum": ["cloud", "device", "hybrid"] },
+          "androidKotlin": { "type": "string", "enum": ["cloud", "device", "hybrid"] },
+          "ios": { "type": "string", "enum": ["cloud", "device", "hybrid"] },
+          "iosSwift": { "type": "string", "enum": ["cloud", "device", "hybrid"] },
+          "web": { "type": "string", "enum": ["cloud", "device", "hybrid"] },
+          "flutter": { "type": "string", "enum": ["cloud", "device"] },
+          "reactnative": { "type": "string", "enum": ["cloud", "device"] },
+          "unity": { "type": "string", "enum": ["cloud"] },
+          "amp": { "type": "string", "enum": ["cloud"] },
+          "cordova": { "type": "string", "enum": ["cloud"] },
+          "shopify": { "type": "string", "enum": ["cloud"] },
+          "cloud": { "type": "string", "enum": ["cloud"] },
+          "warehouse": { "type": "string", "enum": ["cloud"] }
+        },
+        "x-sourceTypeKeyed": true,
+        "x-sdkVisible": true
+      },
+
+      "consentManagement": {
+        "type": "object",
+        "properties": {
+          "cloud": { "$ref": "#/$defs/consentArray" },
+          "warehouse": { "$ref": "#/$defs/consentArray" },
+          "android": { "$ref": "#/$defs/consentArray" },
+          "androidKotlin": { "$ref": "#/$defs/consentArray" },
+          "ios": { "$ref": "#/$defs/consentArray" },
+          "iosSwift": { "$ref": "#/$defs/consentArray" },
+          "web": { "$ref": "#/$defs/consentArray" },
+          "unity": { "$ref": "#/$defs/consentArray" },
+          "amp": { "$ref": "#/$defs/consentArray" },
+          "reactnative": { "$ref": "#/$defs/consentArray" },
+          "flutter": { "$ref": "#/$defs/consentArray" },
+          "cordova": { "$ref": "#/$defs/consentArray" },
+          "shopify": { "$ref": "#/$defs/consentArray" }
+        },
+        "x-sourceTypeKeyed": true,
+        "x-sdkVisible": true
+      },
+
+      "oneTrustCookieCategories": {
+        "type": "object",
+        "properties": {
+          "android": { "$ref": "#/$defs/oneTrustArray" },
+          "ios": { "$ref": "#/$defs/oneTrustArray" },
+          "web": { "$ref": "#/$defs/oneTrustArray" },
+          "unity": { "$ref": "#/$defs/oneTrustArray" },
+          "amp": { "$ref": "#/$defs/oneTrustArray" },
+          "cloud": { "$ref": "#/$defs/oneTrustArray" },
+          "warehouse": { "$ref": "#/$defs/oneTrustArray" },
+          "reactnative": { "$ref": "#/$defs/oneTrustArray" },
+          "flutter": { "$ref": "#/$defs/oneTrustArray" },
+          "cordova": { "$ref": "#/$defs/oneTrustArray" },
+          "shopify": { "$ref": "#/$defs/oneTrustArray" }
+        },
+        "x-sourceTypeKeyed": true,
+        "x-sdkVisible": true
+      },
+
+      "ketchConsentPurposes": {
+        "type": "object",
+        "properties": {
+          "android": { "$ref": "#/$defs/ketchArray" },
+          "ios": { "$ref": "#/$defs/ketchArray" },
+          "web": { "$ref": "#/$defs/ketchArray" },
+          "unity": { "$ref": "#/$defs/ketchArray" },
+          "amp": { "$ref": "#/$defs/ketchArray" },
+          "cloud": { "$ref": "#/$defs/ketchArray" },
+          "warehouse": { "$ref": "#/$defs/ketchArray" },
+          "reactnative": { "$ref": "#/$defs/ketchArray" },
+          "flutter": { "$ref": "#/$defs/ketchArray" },
+          "cordova": { "$ref": "#/$defs/ketchArray" },
+          "shopify": { "$ref": "#/$defs/ketchArray" }
+        },
+        "x-sourceTypeKeyed": true,
+        "x-sdkVisible": true
+      }
+    },
+
+    "$defs": {
+      "consentArray": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "enum": ["custom", "iubenda", "ketch", "oneTrust"],
+              "default": "oneTrust"
+            },
+            "consents": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "consent": {
+                    "type": "string",
+                    "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+                  }
+                }
+              }
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": { "provider": { "const": "custom" } },
+                "required": ["provider"]
+              },
+              "then": {
+                "properties": { "resolutionStrategy": { "type": "string", "enum": ["and", "or"] } },
+                "required": ["resolutionStrategy"]
+              }
+            }
+          ]
+        }
+      },
+      "oneTrustArray": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "oneTrustCookieCategory": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+            }
+          }
+        }
+      },
+      "ketchArray": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "purpose": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+            }
+          }
+        }
+      }
+    },
+
+    "allOf": [
+      {
+        "if": {
+          "properties": {
+            "connectionMode": {
+              "type": "object",
+              "anyOf": [
+                { "required": ["web"], "properties": { "web": { "const": "cloud" } } },
+                { "required": ["ios"], "properties": { "ios": { "const": "cloud" } } },
+                { "required": ["android"], "properties": { "android": { "const": "cloud" } } }
+              ]
+            }
+          },
+          "required": ["connectionMode"]
+        },
+        "then": {
+          "properties": {
+            "restApiKey": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"
+            }
+          },
+          "required": ["restApiKey"]
+        }
+      }
+    ]
+  },
+
+  "sourceTypes": [
+    "android",
+    "androidKotlin",
+    "ios",
+    "iosSwift",
+    "web",
+    "unity",
+    "amp",
+    "cloud",
+    "warehouse",
+    "reactnative",
+    "flutter",
+    "cordova",
+    "shopify"
+  ],
+
+  "connectionModes": {
+    "android": ["cloud", "device", "hybrid"],
+    "androidKotlin": ["cloud", "device", "hybrid"],
+    "web": ["cloud", "device", "hybrid"],
+    "ios": ["cloud", "device", "hybrid"],
+    "iosSwift": ["cloud", "device", "hybrid"],
+    "flutter": ["cloud", "device"],
+    "reactnative": ["cloud", "device"],
+    "unity": ["cloud"],
+    "amp": ["cloud"],
+    "cordova": ["cloud"],
+    "shopify": ["cloud"],
+    "cloud": ["cloud"],
+    "warehouse": ["cloud"]
+  },
+
+  "messageTypes": {
+    "cloud": ["group", "identify", "page", "screen", "track", "alias"],
+    "device": {
+      "web": ["identify", "track", "page"],
+      "android": ["identify", "track"],
+      "androidKotlin": ["identify", "track"],
+      "ios": ["identify", "track"],
+      "iosSwift": ["identify", "track"],
+      "flutter": ["identify", "track"],
+      "reactnative": ["identify", "track"]
+    }
+  },
+
+  "transformAtV1": "router",
+  "saveDestinationResponse": true,
+  "isAudienceSupported": true,
+  "supportsVisualMapper": true,
+  "auth": { "type": "none" },
+  "throttlingCost": {
+    "eventType": { "identify": 2, "track": 1, "page": 1, "screen": 1, "group": 2, "alias": 1 }
+  },
+  "hybridModeCloudEventsFilter": {
+    "web": { "messageType": ["identify", "track", "page"] }
+  }
+}
+```
+
+### Simple Webhook Example
+
+For contrast, here's a cloud-only destination with no source-type-keyed fields:
+
+```json
+{
+  "$schema": "https://rudderstack.com/schemas/destination-definition/v1",
+
+  "name": "WEBHOOK",
+  "displayName": "Webhook",
+  "configVersion": { "version": "1.0", "status": "current" },
+
+  "config": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["webhookUrl"],
+    "additionalProperties": false,
+    "properties": {
+      "webhookUrl": {
+        "type": "string",
+        "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|(?!.*\\.ngrok\\.io)^(?:http(s)?:\\/\\/)[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$",
+        "x-sdkVisible": false
+      },
+      "webhookMethod": {
+        "type": "string",
+        "enum": ["POST", "PUT", "PATCH", "GET", "DELETE"],
+        "default": "POST",
+        "x-sdkVisible": false
+      },
+      "headers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "from": { "type": "string" },
+            "to": { "type": "string" }
+          }
+        },
+        "x-secret": true,
+        "x-sdkVisible": false
+      }
+    }
+  },
+
+  "sourceTypes": [
+    "android",
+    "androidKotlin",
+    "ios",
+    "iosSwift",
+    "web",
+    "unity",
+    "amp",
+    "cloud",
+    "warehouse",
+    "reactnative",
+    "flutter",
+    "cordova",
+    "shopify"
+  ],
+
+  "connectionModes": {
+    "android": ["cloud"],
+    "web": ["cloud"],
+    "ios": ["cloud"],
+    "cloud": ["cloud"],
+    "warehouse": ["cloud"]
+  },
+
+  "messageTypes": {
+    "cloud": ["identify", "track", "page", "screen", "group", "alias"]
+  },
+
+  "transformAtV1": "router",
+  "saveDestinationResponse": true,
+  "auth": { "type": "none" }
+}
+```
+
+Note: No `x-sourceTypeKeyed` annotations — all fields are global. The `headers` field is a genuine nested array, not a source-type-keyed object.
+
+---
+
+## Field Annotations: The `x-` Convention
+
+JSON Schema Draft-07 allows unknown keywords — AJV ignores them by default. We use `x-` prefixed keywords (following OpenAPI convention) for field-level metadata:
+
+| Annotation          | Type      | Replaces                             | Purpose                                                  |
+| ------------------- | --------- | ------------------------------------ | -------------------------------------------------------- |
+| `x-secret`          | `boolean` | `secretKeys` array                   | Field contains sensitive data; stored in secrets service |
+| `x-sdkVisible`      | `boolean` | `includeKeys` / `excludeKeys` arrays | Whether field is sent to SDK in device mode              |
+| `x-immutable`       | `boolean` | `rs-immutable` in schema             | Field cannot be changed after creation                   |
+| `x-sourceTypeKeyed` | `boolean` | `destConfig` per-source-type arrays  | Value is a source-type-keyed object (see next section)   |
+
+### How consumers derive legacy arrays from annotations
+
+The config backend (or deploy script) computes the old arrays by scanning `config.properties`:
+
+```python
+def compute_field_routing(config_properties):
+    include_keys = []
+    secret_keys = []
+    default_config = []
+    source_type_fields = {}  # { "web": [...], "android": [...] }
+
+    for field_name, field_schema in config_properties.items():
+        # SDK visibility
+        if field_schema.get("x-sdkVisible"):
+            include_keys.append(field_name)
+
+        # Secret extraction
+        if field_schema.get("x-secret"):
+            secret_keys.append(field_name)
+
+        # Source-type routing
+        if field_schema.get("x-sourceTypeKeyed"):
+            for source_type in field_schema.get("properties", {}):
+                source_type_fields.setdefault(source_type, []).append(field_name)
+        else:
+            default_config.append(field_name)
+
+    dest_config = {"defaultConfig": default_config, **source_type_fields}
+    return include_keys, secret_keys, dest_config
+```
+
+This is deterministic — the same definition.json always produces the same arrays. No manual sync needed.
+
+---
+
+## Source-Type-Keyed Fields: The Complete Picture
+
+This is the most important design decision in the consolidation. Some config fields store per-source-type values as objects with source type keys:
+
+```json
+{
+  "restApiKey": "xxx",
+  "dataCenter": "US-01",
+  "trackAnonymousUser": { "web": true },
+  "connectionMode": { "web": "device", "android": "cloud" },
+  "consentManagement": {
+    "web": [{ "provider": "oneTrust", "consents": [...] }],
+    "android": [{ "provider": "ketch", "consents": [...] }]
+  }
+}
+```
+
+This data shape is **unchanged** by consolidation. The question is how to represent it in definition.json's schema so that:
+
+1. AJV validates the actual stored data correctly
+2. Consumers can programmatically distinguish source-type-keyed objects from genuine nested objects
+3. The config backend knows which fields to unwrap per source type
+
+### The problem
+
+An `{ "type": "object" }` field could be either:
+
+- **Source-type-keyed**: `trackAnonymousUser: { web: true }` — unwrapped to `true` when serving to web SDK
+- **Genuine nested object**: `headers: [{ from: "X-Custom", to: "value" }]` — passed through as-is
+
+You cannot tell them apart from the JSON Schema alone.
+
+### The solution: `x-sourceTypeKeyed: true`
+
+A simple boolean annotation on source-type-keyed fields:
+
+```json
+"trackAnonymousUser": {
+  "type": "object",
+  "properties": { "web": { "type": "boolean" } },
+  "x-sourceTypeKeyed": true,
+  "x-sdkVisible": true
+}
+```
+
+vs. a genuine nested object (no annotation):
+
+```json
+"headers": {
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "from": { "type": "string" },
+      "to": { "type": "string" }
+    }
+  }
+}
+```
+
+### Why this works
+
+Based on thorough codebase analysis:
+
+1. **Clean separation exists today.** Across all 239 destinations, there are ZERO hybrid fields that mix source-type keys with non-source-type keys. Every field is either fully source-type-keyed or not at all.
+2. **1:1 mapping with `destConfig`.** In the current system, every field in `destConfig.web`, `destConfig.android`, etc. (non-defaultConfig) is a source-type-keyed object. Every field in `destConfig.defaultConfig` is flat. `x-sourceTypeKeyed` preserves this exact distinction.
+3. **Source types are encoded in schema properties.** If `connectionMode` has `properties.web` and `properties.android`, those are the source types it applies to. No need for a separate `x-sourceTypes: [...]` list — the schema itself is the list.
+4. **AJV ignores it.** AJV validates against the actual `type: "object"` schema with source-type properties. The `x-sourceTypeKeyed` annotation is invisible to validation. The stored data shape is validated correctly.
+5. **Config backend reads it.** The source config service checks `x-sourceTypeKeyed` to decide whether to unwrap:
+
+```typescript
+// New approach — reads annotation from definition.json
+for (const [key, fieldSchema] of Object.entries(definition.config.properties)) {
+  if (fieldSchema['x-sourceTypeKeyed']) {
+    // Unwrap: config.connectionMode.web → "device"
+    if (originalConfig[key]?.[sourceType] !== undefined) {
+      set(filteredConfig, key, originalConfig[key][sourceType]);
+    }
+  } else {
+    // Flat value: config.dataCenter → "US-01"
+    set(filteredConfig, key, originalConfig[key]);
+  }
+}
+```
+
+### All known source type keys
+
+The set of valid source type keys (13 values) is fixed and defined in `sourceTypes` at the top level:
+
+```
+android, androidKotlin, ios, iosSwift, web, unity, amp,
+cloud, warehouse, reactnative, flutter, cordova, shopify
+```
+
+CI can validate that every property key inside an `x-sourceTypeKeyed` field is a member of this set.
+
+### Commonly seen source-type-keyed fields
+
+These fields appear as source-type-keyed objects across most destinations:
+
+| Field                      | Typical inner type          | Purpose                                    |
+| -------------------------- | --------------------------- | ------------------------------------------ |
+| `connectionMode`           | `string` (enum)             | User's chosen connection mode per platform |
+| `useNativeSDK`             | `boolean`                   | Whether to use native SDK on this platform |
+| `consentManagement`        | `array` of consent objects  | Consent provider config per platform       |
+| `oneTrustCookieCategories` | `array` of category objects | OneTrust cookie categories per platform    |
+| `ketchConsentPurposes`     | `array` of purpose objects  | Ketch consent purposes per platform        |
+
+Destination-specific source-type-keyed fields (e.g., `trackAnonymousUser`, `enableBrazeLogging` for Braze) are scoped to specific source types.
+
+---
+
+## ui-config.json (Separate, Rendering-Only)
+
+ui-config.json continues to exist as a separate file. It provides rendering hints keyed by `configKey`, which must match a property name in definition.json's `config.properties`.
+
+### What ui-config.json defines
+
+- Component type (`textInput`, `checkbox`, `singleSelect`, `dynamicForm`, `dynamicCustomForm`, `tagInput`)
+- Layout (sections, groups, ordering)
+- Conditional visibility (`preRequisites`, `conditions`)
+- Placeholders, notes, callouts
+- Row field definitions for dynamic forms (`rowFields`)
+- `sdkTemplate` — SDK-specific settings (source-type-keyed fields rendered as toggles)
+- `consentSettingsTemplate` — consent management UI
+
+### What ui-config.json does NOT define
+
+- Field types, enums, defaults, patterns → definition.json
+- Secret/immutable status → definition.json `x-secret`, `x-immutable`
+- SDK visibility → definition.json `x-sdkVisible`
+- Validation rules → definition.json JSON Schema
+- Source type scope → definition.json `x-sourceTypeKeyed` + schema properties
+
+### Enforcement
+
+CI validates that every `configKey` in ui-config.json maps to a property in definition.json. Missing mappings are errors.
+
+During transition, ui-config.json can still contain redundant `type`, `enum`, `default`, `regex`, and `secret` fields — they are ignored by the web app once it reads metadata from definition.json instead. These can be removed incrementally.
+
+---
+
+## How Consumers Read the Files
+
+| Consumer           | definition.json                                                                                                                                      | ui-config.json                            |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| **AJV validators** | `config` block directly (standard JSON Schema validation)                                                                                            | Not read                                  |
+| **Web app**        | `config.properties` for field metadata (types, enums, defaults, `x-` annotations)                                                                    | Rendering: components, layout, conditions |
+| **Config backend** | `config.properties.x-secret` for secret extraction; `x-sourceTypeKeyed` for per-source-type unwrapping; `x-sdkVisible` for include/exclude filtering | Not read                                  |
+| **Data plane**     | Receives config instances, not definitions                                                                                                           | Not read                                  |
+| **Terraform/CLI**  | `config` block for resource schema generation                                                                                                        | Not read                                  |
+| **Deploy script**  | Computes legacy arrays from `x-` annotations (transition period)                                                                                     | Passes through as `uiConfig` DB column    |
+
+---
+
+## Database Column Mapping
+
+### During transition
+
+The deploy script reads definition.json and computes the old column values:
+
+| DB Column      | Computed From                                                                                                                                                                          |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`         | `definition.name`                                                                                                                                                                      |
+| `displayName`  | `definition.displayName`                                                                                                                                                               |
+| `config`       | Top-level fields (`sourceTypes`, `connectionModes`, `messageTypes`, `transformAtV1`, `auth`, etc.) + computed arrays (`includeKeys`, `secretKeys`, `destConfig` from `x-` annotations) |
+| `configSchema` | `definition.config` block (the JSON Schema, verbatim)                                                                                                                                  |
+| `uiConfig`     | ui-config.json contents                                                                                                                                                                |
+| `options`      | `definition.options`                                                                                                                                                                   |
+
+This means existing consumers (config backend, web app) continue working with the same DB column shapes while they're migrated to read `x-` annotations directly.
+
+### After full migration
+
+The `config` DB column can be simplified — `destConfig`, `includeKeys`, `excludeKeys`, `secretKeys` arrays are no longer stored since consumers derive them from `configSchema` annotations. The `config` column holds only platform metadata (`sourceTypes`, `connectionModes`, etc.) and behavior flags (`transformAtV1`, `auth`, etc.).
+
+---
+
+## What Changes When This Is Done
+
+| Before                                                                          | After                                                                |
+| ------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Edit db-config + schema for one field change                                    | Edit definition.json (1 file for config definition)                  |
+| `schemaGenerator.py` generates schema.json from ui-config + db-config           | Schema IS definition.json's `config` block; no generation            |
+| `destConfig`, `includeKeys`, `secretKeys` as manually maintained arrays         | `x-sourceTypeKeyed`, `x-sdkVisible`, `x-secret` as field annotations |
+| Source of truth split between db-config and schema                              | definition.json is the single source of truth                        |
+| Same field info in 3 places (db-config arrays, schema types, ui-config options) | Field defined once in schema; ui-config only adds rendering          |
+| Version directory has 3 files                                                   | Version directory has 2 files (definition.json + ui-config.json)     |
+| Adding a field: edit db-config arrays + schema properties + ui-config           | Adding a field: edit schema properties + ui-config                   |
+| `consentManagement` schema repeated 13x (one per source type, ~600 lines)       | Uses `$ref` to `$defs` — defined once, referenced per source type    |
+
+---
+
+## Migration Path
+
+### Phase 1: Build tooling
+
+1. Build `merge-to-definition.py`: reads db-config.json + schema.json → produces definition.json
+
+- Maps `secretKeys` → `x-secret: true` on each field
+- Maps `includeKeys` → `x-sdkVisible: true` on each field
+- Maps non-defaultConfig `destConfig` fields → `x-sourceTypeKeyed: true`
+- Moves `supportedSourceTypes` → `sourceTypes`, `supportedConnectionModes` → `connectionModes`, etc.
+- Deduplicates consent/oneTrust schemas using `$defs` + `$ref`
+
+2. Build meta-schema for definition.json (validates the structure itself)
+3. Build `definition-to-legacy.py`: reads definition.json → produces old db-config.json + schema.json (backward compat)
+
+### Phase 2: Generate and validate
+
+1. Run `merge-to-definition.py` for all 239 destinations
+2. Validate each definition.json against the meta-schema
+3. Validate each definition.json's `config` block validates the same config data as the existing schema.json (round-trip test)
+4. Run `definition-to-legacy.py` and diff against originals — must be identical
+
+### Phase 3: Deploy with backward compatibility
+
+1. Update `deployToDB.py` to read definition.json (primary) with fallback to old files
+2. Deploy script computes legacy arrays from `x-` annotations and writes to same DB columns
+3. All consumers continue working unchanged — they read the same DB column shapes
+
+### Phase 4: Migrate consumers
+
+1. Config backend reads `x-sourceTypeKeyed` from `configSchema` instead of `destConfig` from `config`
+2. Config backend reads `x-secret` from `configSchema` instead of `secretKeys` from `config`
+3. Config backend reads `x-sdkVisible` from `configSchema` instead of `includeKeys` from `config`
+4. Web app reads field metadata (type, enum, default) from `configSchema.properties` instead of ui-config.json
+
+### Phase 5: Cleanup
+
+1. Remove `schemaGenerator.py`
+2. Remove db-config.json and schema.json files (definition.json is the source of truth)
+3. Remove legacy array computation from deploy script
+4. Simplify `config` DB column (drop `destConfig`, `includeKeys`, `secretKeys`)
+
+---
+
+## Open Design Questions
+
+1. `**sdkTemplate` and `consentSettingsTemplate`\*\* — These are hidden UI sections in ui-config.json. They define source-type-keyed fields (like `enableBrazeLogging`) and consent forms. Do they stay in ui-config.json as rendering concerns, or move to definition.json since they define config structure? Recommendation: they stay in ui-config.json for rendering, but their `configKey` references must map to fields in definition.json.
+2. `**ui-config.jt` templates\*\* — Complex destinations like GA4 use Jsonnet templates (`ui-config.jt` + `ui-default.json`) that generate ui-config.json. These continue to work — they generate rendering instructions, and the configKey references are validated against definition.json.
+3. `**connectionConfigSchema` and `connectionUIConfig`\*\* — These are newer DB columns for connection-level config (separate from destination config). They follow the same pattern and should get the same `x-` annotation treatment in a follow-up.
+4. `**$defs` and `$ref` support\*\* — Current schema.json files don't use `$ref`. The consolidated definition.json uses `$ref` to eliminate the 600+ lines of duplicated consent schema. Need to verify AJV supports this with our configuration (it does with Draft-07, but need to confirm with `useDefaults: true`).
+5. **Pre-computing vs. on-demand** — Should the config backend pre-compute `destConfig`-equivalent field lists at definition load time (once) and cache them, or compute per request? Recommendation: pre-compute at load time — it's a simple scan of properties, and definitions change rarely.

--- a/docs/integrations-definition-versioning/versioning-design.md
+++ b/docs/integrations-definition-versioning/versioning-design.md
@@ -191,7 +191,7 @@ src/configurations/destinations/braze/
 ├── schema.json           # Always latest version
 ├── CHANGELOG.md          # Documents what changed in each version
 ├── migrations/
-│   └── 1-to-2.js        # Forward migration logic (code)
+│   └── 1-to-2.json      # Migration declaration (metadata only; code lives in config backend)
 └── versions/
     └── 1/
         ├── db-config.json   # v1's own metadata (status, deprecation dates) + config
@@ -357,9 +357,9 @@ The deployment script (`scripts/deployToDB.py`) merges all three files into a si
 **How consumers read it:**
 
 - **Version-unaware consumers** (existing) — read top-level fields as before. Nothing changes.
-- **Config backend** (version-aware) — at startup, compiles AJV schemas for each version: top-level `configSchema` for the current version, `versions.{major}.configSchema` for older versions. When validating a config, it selects the compiled schema matching `configVersion`.
+- **Config backend** (version-aware) — at startup, compiles AJV schemas for each version: top-level `configSchema` for the current version, `versions.{major}.configSchema` for older versions. When processing a request, it selects the version-matched schema **and** the version-matched `config` metadata (`secretKeys`, `includeKeys`, `destConfig`, etc.) — not just the schema. This is critical because these lists change between versions (e.g., v1's `secretKeys: ["restApiKey"]` vs v2's `secretKeys: ["apiKey"]`).
 - **Web app** (version-aware) — reads `versions.{major}.uiConfig` when rendering forms for an older version's config. Shows migration banner.
-- **Data plane** — does not read the definition record. It receives the config instance (already version-tagged with `configVersion`) from the config backend. The data plane dispatches to the appropriate version-tagged handler based on `configVersion`.
+- **Data plane** — does not read the definition record. It receives the config instance from the config backend, which includes `configVersion` in the destination config payload. The data plane dispatches to the appropriate version-tagged handler based on `configVersion`.
 
 For integrations that haven't been versioned yet, `configVersion` and `versions` are absent — they implicitly operate as `1.0`.
 
@@ -553,19 +553,47 @@ The key invariant: **existing stored configs with `null` version are always trea
 
 ## Migration Service
 
-Migration runs as part of the existing config backend service — no new microservice needed. The migration code (JS files) lives in this repo alongside the definition it migrates.
+Migration runs as part of the existing config backend service — no new microservice needed. Migration is split across two repos:
 
-### Migration File Format
+- **Declarations** (metadata) live in this repo alongside the definition
+- **Implementations** (code) live in the config backend where they execute
 
-The migration file only contains the transformation logic. It does not declare required inputs or preview output — those are computed by the config backend.
+### Migration Declaration (this repo)
 
-```javascript
-// migrations/1-to-2.js
-module.exports = {
+Each breaking change includes a JSON declaration that describes the migration without containing the transformation code:
+
+```json
+// migrations/1-to-2.json
+{
+  "from": 1,
+  "to": 2,
+  "description": "Added account support, consolidated API key fields"
+}
+```
+
+This declaration serves CI validation — the break detection guardrail checks that every breaking change has a corresponding declaration. The actual migration logic is not here.
+
+### Migration Implementation (config backend)
+
+The transformation code lives in the config backend repo, following a mirrored directory structure:
+
+```
+rudder-config-backend/
+└── src/migrations/destinations/
+    ├── braze/
+    │   ├── 1-to-2.ts          # Migration implementation
+    │   └── 1-to-2.test.ts     # Tests with sample configs
+    ├── am/
+    │   └── 1-to-2.ts
+    └── registry.ts             # Auto-discovers and registers migrations
+```
+
+```typescript
+// src/migrations/destinations/braze/1-to-2.ts
+export const migration = {
   version: { from: 1, to: 2 },
-  description: 'Added account support, consolidated API key fields',
 
-  migrate(config) {
+  migrate(config: Record<string, unknown>) {
     const migrated = { ...config };
 
     // Rename
@@ -582,6 +610,25 @@ module.exports = {
   },
 };
 ```
+
+**Deployment ordering:** Config backend (with migration code) deploys first, then definitions deploy to the database. This mirrors the existing pattern — transformer deploys version-tagged handlers before definitions land.
+
+**Coordination:** A breaking change requires PRs in both repos on the same ticket. CI in this repo validates migration declarations exist; CI in config backend validates implementations exist and pass smoke tests against sample configs.
+
+### Why Migration Code Lives in Config Backend (not this repo)
+
+Migration functions are imperative code that executes in the config backend. Keeping them where they run gives us:
+
+- **Standard TypeScript** — type-safe, debuggable, testable with the config backend's existing test framework
+- **No stored code execution** — no `vm` module, no `eval`, no sandboxing
+- **Access to utilities** — lodash, shared helpers, etc.
+- **This repo stays declarative** — schemas, metadata, and UI config are all data, not code
+
+**Rejected alternatives:**
+
+- **Store migration JS in the definition record** — deploy script serializes code as a string, config backend executes via Node.js `vm` module. Rejected: stored code execution is a security surface; debugging serialized strings is painful; no TypeScript support; can't use utility libraries.
+- **Config backend depends on this repo as npm package** — import migration functions directly. Rejected: tight deployment coupling; config backend must redeploy for every new migration, partially defeating the decoupling this design provides.
+- **Migration files deployed to shared storage (S3)** — deploy script uploads JS to S3, config backend loads at runtime. Rejected: extra infrastructure; cache invalidation complexity; another failure point.
 
 ### How Migration Works
 
@@ -730,7 +777,7 @@ Non-breaking fixes (bug fixes that don't change the contract) can still go to ol
 
 1. Copy current root files (`db-config.json`, `ui-config.json`, `schema.json`) to `versions/1/`
 2. Add `configVersion` to `versions/1/db-config.json`: `{ "version": "1.0", "status": "supported" }`
-3. Create migration file: `migrations/1-to-2.js`
+3. Create migration declaration: `migrations/1-to-2.json` (and corresponding implementation in config backend)
 4. Update root `db-config.json` with `configVersion`: `{ "version": "2.0", "status": "current" }`
 5. Make breaking changes to root `db-config.json`, `ui-config.json` (and regenerate `schema.json`)
 6. Deploy definitions — the deploy script merges `versions/1/` into the definition record under `versions.1`
@@ -752,7 +799,7 @@ Non-breaking fixes (bug fixes that don't change the contract) can still go to ol
 1. After deprecation period → update `versions/1/db-config.json`'s `configVersion.status` to `"deprecated"` (warnings on every operation)
 2. After retirement date → update status to `"retired"` (requests rejected, forced migration required)
 3. Data plane drops `1.0` handling
-4. Optionally clean up `versions/1/` and `migrations/1-to-2.js`
+4. Optionally clean up `versions/1/`, `migrations/1-to-2.json`, and the migration implementation in config backend
 
 ### How Validation Works Per Version
 
@@ -782,9 +829,9 @@ Client sends: { config: { apiKey: "xxx", accountId: "abc" } }  (no version, new 
 
 The CI pipeline enforces versioning discipline automatically:
 
-1. **Break detection** — Diffs schema.json + db-config.json against the previous version. If a breaking change is detected, the PR must include a migration file and a `versions/{major}/` directory for the old version. Otherwise it fails.
+1. **Break detection** — Diffs schema.json + db-config.json against the previous version. If a breaking change is detected, the PR must include a migration declaration (`migrations/X-to-Y.json`) and a `versions/{major}/` directory for the old version. Otherwise it fails.
 2. **Version directory integrity** — Changes to `versions/` directories must be accompanied by a minor version bump in that version's `db-config.json`.
-3. **Migration smoke tests** — Runs each migration file against a set of sample configs, then validates the output against the target version's schema. Ensures `migrate()` produces configs that pass AJV validation (with the exception of fields that require user input).
+3. **Migration declaration validation** — Checks that every breaking change has a corresponding migration declaration in this repo. The actual migration **smoke tests** (running `migrate()` against sample configs and validating output) run in the config backend's CI, where the implementation lives.
 4. **Version bookkeeping** — Checks that every `versions/{major}/` directory has a valid `configVersion` in its `db-config.json`, and that no version directory exists without being referenced.
 5. **Changelog required** — A PR that bumps a major version must include a `CHANGELOG.md` entry.
 6. **Version ceiling** — Rejects PRs that would create more than 2 simultaneously supported major versions.
@@ -826,7 +873,7 @@ The CI pipeline enforces versioning discipline automatically:
 2. **Multi-version storage** — configs stored as-is in their original version, tagged with version
 3. **User-triggered migration** — users explicitly migrate when ready; not batch-forced
 4. **Migration via normal update API** — no implicit migration during updates. Config backend only validates and persists. All clients can use the read-only migrate endpoint to get the migrated config first, then submit a normal update with the complete v2 config.
-5. **Migration as code** — JS migration files contain only `migrate()` transform; used by the migrate endpoint to convert stored configs to target version shape
+5. **Migration split: declarations here, code in config backend** — migration metadata (JSON declarations) live in this repo for CI validation; migration implementations (TypeScript) live in the config backend where they execute. No stored code execution.
 6. **Data plane handles multiple versions** — version-tagged handlers; router dispatches by configVersion
 7. **Forward-only, chainable migrations** — v1→v2→v3; no downgrade
 8. **Integration-level versioning** — not workspace-level; each integration instance carries its own version
@@ -860,6 +907,8 @@ The CI pipeline enforces versioning discipline automatically:
 3. **Deprecation: multi-channel communication** — API headers (RFC 8594) + dashboard banners + email + changelog
 4. **Definition storage: single record with nested versions** — `versions.{major}` nested in the definition record; config backend projects the right version at read time
 5. **Instance storage: `configVersion` column on `destinations` table** — nullable string; `null` = implicit major version `1`
+6. **Version-specific config processing** — config backend uses version-matched `config` metadata (`secretKeys`, `includeKeys`, `destConfig`) when processing requests — not just the version-matched schema
+7. **Data plane `configVersion` delivery** — config backend includes `configVersion` in the destination config payload sent to the data plane, enabling version-tagged handler dispatch
 
 ### Future
 

--- a/docs/integrations-definition-versioning/versioning-design.md
+++ b/docs/integrations-definition-versioning/versioning-design.md
@@ -1,0 +1,875 @@
+# Integrations Versioning
+
+## Summary
+
+This document defines how we evolve integration definitions (destinations and sources) over time without breaking existing configurations. Today, any breaking change to an integration's config requires careful release coordination and forces all consumers (Web UI, Terraform, Public API) to update simultaneously.
+
+This design introduces per-integration versioning so breaking changes can be rolled out easily, with each client migrating on its own schedule.
+
+### Goals
+
+- Introduce breaking changes to integration definitions without disrupting live configurations
+- Let public API/Terraform users stay on older integration versions until they're ready to migrate
+- Provide self-service, user-controlled migration
+- Replace ad-hoc compatibility workarounds with a formal versioning contract
+
+### Scope
+
+**Destination definitions first.** Source definitions can adopt the same pattern once the destination rollout is proven.
+
+Connection configurations (rETL) and other config types are out of scope for now.
+
+---
+
+## Current State
+
+### Integration Definitions
+
+Each integration (source or destination) in the `rudder-integrations-config` repository is defined using a standardized three-file pattern called a **RudderStack Resource Definition**. There are currently **239 destinations** and **116 sources** under `src/configurations/`.
+
+The three files have distinct, non-overlapping responsibilities:
+
+| File             | Concern              | What it contains                                                                                                                                                                                                                                          | Consumed by                                       |
+| ---------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `db-config.json` | **Service behavior** | Metadata and capability declarations — auth config, supported source types, connection modes, message types. Lists field **names** in `destConfig` arrays, `includeKeys`, `secretKeys`, etc.                                                              | All services (web app, control plane, data plane) |
+| `schema.json`    | **Input validation** | JSON Schema Draft-07 that validates config payloads at the API layer. Defines field **types**, defaults, enum values, regex patterns, and conditional validation (`allOf`/`if-then`). Auto-generated from ui-config + db-config via `schemaGenerator.py`. | Config backend (AJV at runtime)                   |
+| `ui-config.json` | **UI rendering**     | Drives the web app's form rendering — field widget types, labels, sections, groups, ordering, conditional visibility (`preRequisites`/`conditions`). Not used by any backend service.                                                                     | Web app only                                      |
+
+A single configuration field (e.g., `restApiKey`) is described across all three files: its **name** appears in db-config's `destConfig` arrays, its **type and validation rules** in schema.json, and its **UI presentation** in ui-config.json. The `configKey` in ui-config maps 1:1 to property names in schema.json and field names in db-config lists.
+
+### Clients
+
+Multiple clients produce and consume integration configurations:
+
+- **Web UI** — reads definition records (loaded from `db-config.json` and `ui-config.json`) to render config forms
+- **Public API** (`rudder-api`) — thin API layer that accepts config payloads, forwards to config backend
+- **Terraform provider** — transforms HCL to API payloads via a `ConfigProperty` pipeline (snake_case → camelCase, array flattening, discriminators), calls the public API
+- **CLI** — reads/writes YAML specs, calls the public API
+
+The **config backend** (`rudder-config-backend`) is the service that validates configs against definition schemas (AJV), extracts secrets to an external secrets service, and persists to the `destinations` table. It loads all definition schemas into memory at startup and compiles them with AJV.
+
+The **data plane** (rudder-transformer) consumes stored config instances by directly accessing field names (e.g., `config.restApiKey`). It does not read the definition files — it receives config data from the config backend.
+
+### Deployment Sequence
+
+1. Transformer code (data plane) — deployed first so it can handle new field names
+2. Integration definitions (this repo) — deployed to `destination_definitions` table via deploy script
+3. Existing stored configs — migrated via ad-hoc scripts when fields change
+
+---
+
+## Problem Statement
+
+Integration configurations are an **implicit contract** shared across the web app, public API, Terraform provider, control plane, and data plane — with no formal mechanism for evolving that contract.
+
+When the team needs to make a breaking change (add a required field, rename a key, restructure config) in the definition, every consumer must update simultaneously.
+
+In practice, this means:
+
+### 1. Coordination Overhead
+
+A single field change can require synchronized releases across 3+ repositories (integrations-config, transformer, control plane) and 4+ client surfaces (web app, API, Terraform).
+
+### 2. Breaking Existing Configs
+
+Stored configs in the database were created against an older definition. When the definition changes — say a field is renamed or a new required field is added — those stored configs become invalid against the new schema. There's no mechanism to keep old configs working while new configs use the updated definition.
+
+### 3. Migration Burden
+
+Every structural change requires a one-off migration script to update stored configs in the database. These scripts are created on ad-hoc basis.
+
+### 4. Client Drift
+
+The web app can be updated in lockstep with definition changes — it's deployed by the same team. But external clients can't:
+
+- **Terraform** users have `.tf` files checked into their repos with hardcoded field names. A field rename causes `terraform plan` to show unexpected diffs or fail entirely. State drift is a production infrastructure risk.
+- **Public API** consumers have integrations built against specific field names. Breaking changes without warning erode customer trust.
+
+| Client         | Challenge                            | Impact                             |
+| -------------- | ------------------------------------ | ---------------------------------- |
+| **Web UI**     | Can be migrated during releases      | Low — automatic migration possible |
+| **Terraform**  | State drift and plan failures        | High — breaks existing pipelines   |
+| **Public API** | Integration breakage without warning | High — customer trust impact       |
+
+### 5. Ad-Hoc Workarounds Create Tech Debt
+
+Without versioning, the team resorts to compatibility hacks: keeping both old and new field names, creating resources behind the scenes for legacy configs, writing ambiguous validation logic that accepts both formats. These workarounds accumulate as technical debt.
+
+### Concrete Example: Account Support
+
+Adding account support to integrations (e.g., `rudderAccountId` as required field) forces existing API/Terraform users to update immediately. The current backwards-compatibility attempt illustrates all of the above pain points:
+
+- Users updating via Terraform may inadvertently create duplicate accounts
+- No clear way to identify which account corresponds to which configuration
+- Validation becomes complex with mixed old/new integration definitions
+- Creating accounts behind the scenes for legacy integrations leads to orphaned resources
+- Applies to ANY integration (not just warehouses) — Iterable, Braze have similar org/project structures
+
+### Change Categories
+
+| Change Type             | Example                                                 | Severity             | Versioning Required |
+| ----------------------- | ------------------------------------------------------- | -------------------- | ------------------- |
+| Optional field addition | `deleteStagingFiles` (default: true)                    | Non-breaking         | No                  |
+| Required field addition | `rudderAccountId` now mandatory                         | Breaking             | Yes                 |
+| Field removal           | Deprecated `apiKey` removed                             | Breaking             | Yes                 |
+| Field restructuring     | `oneTrustCookieCategories` becomes source type specific | Breaking             | Yes                 |
+| Validation change       | Regex pattern update                                    | Potentially breaking | Conditional         |
+
+See [change-scenarios.md](./change-scenarios.md) for the full taxonomy of 65+ change scenarios across schema.json, db-config.json, and ui-config.json.
+
+---
+
+## Solution
+
+The core idea is to **assign a version to each integration definition change** and let multiple versions coexist.
+
+When a breaking change is needed, a new major version is created. Existing configs continue to work against the old version's schema. Users migrate to the new version on their own schedule — through the web UI, CLI, or API.
+
+This means:
+
+- **No big-bang releases.** The definition, data plane, and user migration are decoupled steps.
+- **No broken configs.** Stored configs are always valid against the version they were created with.
+- **No forced client updates.** Terraform and CLI users stay on the old version until they choose to upgrade.
+- **No ad-hoc scripts.** Migration logic is code that ships with the definition, testable in CI.
+
+### How It Works
+
+```
+Client submits v1.0 config
+       ↓
+Validate against v1.0 schema
+       ↓
+Store v1.0 as-is (tagged with version)
+       ↓
+Serve v1.0 back to client unchanged
+       ↓
+User triggers v1.0 → v2.0 migration when ready
+```
+
+### Why This Approach
+
+We evaluated two strategies for handling multiple versions:
+
+| Criteria                  | Translate-on-Write (rejected)    | Version-Aware Storage (adopted)  |
+| ------------------------- | -------------------------------- | -------------------------------- |
+| Implementation complexity | High (bidirectional mapping)     | Medium                           |
+| Data integrity risk       | High (translation bugs)          | Low (original preserved)         |
+| Supports field removal    | No (can't reverse a deletion)    | Yes                              |
+| Supports restructuring    | Difficult                        | Yes                              |
+| Client flexibility        | Limited (all clients see latest) | High (each client picks version) |
+| Storage overhead          | Low                              | Slightly higher                  |
+
+**Translate-on-write** converts old configs to the latest format before storing, and reverse-translates on read. This sounds simpler but breaks down for destructive changes (field removal, type changes) where reverse translation is impossible. It also means you can never serve the original config back to a client that expects the old format.
+
+**Version-aware storage** preserves configs exactly as submitted, tagged with their version. Each version has its own schema for validation. Migration is explicit and user-controlled. This is the approach we adopt.
+
+---
+
+## Architecture
+
+### Version Identifier
+
+Each integration definition is versioned independently using `major.minor` semantics:
+
+- **Major version:** Breaking changes requiring explicit migration
+- **Minor version:** Non-breaking additions or corrections with backward compatibility
+
+**Clients send only the major version** (e.g., `"configVersion": 2`). The config backend resolves it to the latest minor of that major (e.g., `2.1`) and stores the full `major.minor` in the database. This means:
+
+- Clients never need to track minor versions
+- Schema defaults from the latest minor are always applied (via AJV `useDefaults: true`)
+- The stored value reflects exactly which schema was used for validation
+
+For human-readable references (docs, changelogs), the convention is `{integration_type}@{major}.{minor}` (e.g., `BRAZE@2.0`, `AM@1.3`).
+
+### File Structure
+
+```
+src/configurations/destinations/braze/
+├── db-config.json        # Always latest version (2.0), includes configVersion
+├── ui-config.json        # Always latest version
+├── schema.json           # Always latest version
+├── CHANGELOG.md          # Documents what changed in each version
+├── migrations/
+│   └── 1-to-2.js        # Forward migration logic (code)
+└── versions/
+    └── 1/
+        ├── db-config.json   # v1's own metadata (status, deprecation dates) + config
+        ├── schema.json      # v1's validation schema (editable for minor fixes)
+        └── ui-config.json   # v1's UI rendering config
+```
+
+### Version Changelog
+
+Each versioned integration includes a `CHANGELOG.md` that documents what changed in each version. This serves as the user-facing reference for understanding version differences — what fields were added, removed, renamed, or restructured.
+
+```markdown
+# Braze Changelog
+
+## 2.0 (2026-04-01)
+
+- **BREAKING**: `restApiKey` renamed to `apiKey`
+- **BREAKING**: `accountId` is now required
+- `region` field added (defaults to "US")
+- `legacyEndpoint` removed
+
+## 1.1 (2026-03-15)
+
+- Tightened regex validation for `restApiKey`
+
+## 1.0 (2025-01-01)
+
+- Initial version
+```
+
+The changelog is:
+
+- **Maintained by the developer** making the version change (alongside the migration file and definition updates)
+- **Surfaced in the web app** migration banner so users understand what's changing before they upgrade
+- **Included in API deprecation notices** and documentation
+- **Enforced by CI** — a PR that bumps a major version must include a changelog entry
+
+The version directories are not frozen snapshots — they are living major version tracks.
+
+When a non-breaking fix needs to go to older versions, the files in `versions/1/` are edited directly and the minor version in that directory's `db-config.json` is bumped (1.0 → 1.1). Breaking changes are never applied to older versions — users must migrate to the latest version.
+
+Only major versions get their own directory; minor versions are edits within the same directory.
+
+### Version Metadata
+
+#### Version Metadata Schema
+
+Every `db-config.json` — whether root or inside a version directory — uses the same `configVersion` object to describe itself:
+
+| Field             | Type     | Required | Description                                             |
+| ----------------- | -------- | -------- | ------------------------------------------------------- |
+| `version`         | `string` | Yes      | Semantic version (`major.minor`)                        |
+| `status`          | `string` | Yes      | One of: `current`, `supported`, `deprecated`, `retired` |
+| `deprecationDate` | `string` | No       | ISO date when deprecation begins                        |
+| `retirementDate`  | `string` | No       | ISO date when version is retired                        |
+| `message`         | `string` | No       | Human-readable migration guidance                       |
+
+**Root `db-config.json`** (always the latest version):
+
+```json
+{
+  "name": "BRAZE",
+  "displayName": "Braze",
+  "configVersion": {
+    "version": "2.0",
+    "status": "current"
+  },
+  "config": { ... }
+}
+```
+
+**Version directory `db-config.json`** (e.g., `versions/1/db-config.json`):
+
+```json
+{
+  "name": "BRAZE",
+  "displayName": "Braze",
+  "configVersion": {
+    "version": "1.0",
+    "status": "deprecated",
+    "deprecationDate": "2026-06-01",
+    "retirementDate": "2026-12-01",
+    "message": "Please migrate to 2.0."
+  },
+  "config": { ... }
+}
+```
+
+The same `configVersion` object shape is used in every db-config.json — root and version directories. No separate catalog array needed; the deploy script assembles the full picture by scanning all version directories.
+
+#### How Definitions Are Stored in the Database
+
+The deployment script (`scripts/deployToDB.py`) merges all three files into a single flat JSON object and stores it as one record per integration in the `destination_definitions` table. The database doesn't know about the three-file split.
+
+**Current** (no versioning) — flat merged blob:
+
+```json
+{
+  "name": "BRAZE",
+  "displayName": "Braze",
+  "config": {
+    "destConfig": { "defaultConfig": ["restApiKey", "dataCenter"], "web": ["enableBrazeLogging"] },
+    "secretKeys": ["restApiKey"],
+    "includeKeys": ["appKey", "dataCenter"],
+    "supportedSourceTypes": ["android", "ios", "web", "cloud"],
+    ...
+  },
+  "configSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["restApiKey", "dataCenter"],
+    "properties": { "restApiKey": { "type": "string" }, ... }
+  },
+  "uiConfig": { "baseTemplate": [ ... ] },
+  ...
+}
+```
+
+**With versioning** — same record, top-level = latest version, older versions nested under `versions`:
+
+```json
+{
+  "name": "BRAZE",
+  "displayName": "Braze",
+  "configVersion": { "version": "2.0", "status": "current" },
+  "config": {
+    "destConfig": { "defaultConfig": ["apiKey", "accountId", "dataCenter"], "web": ["enableBrazeLogging"] },
+    "secretKeys": ["apiKey"],
+    ...
+  },
+  "configSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "required": ["apiKey", "accountId", "dataCenter"],
+    "properties": { "apiKey": { "type": "string" }, "accountId": { "type": "string" }, ... }
+  },
+  "uiConfig": { "baseTemplate": [ ... ] },
+
+  "versions": {
+    "1": {
+      "configVersion": { "version": "1.0", "status": "deprecated", "deprecationDate": "2026-06-01" },
+      "config": {
+        "destConfig": { "defaultConfig": ["restApiKey", "dataCenter"], "web": ["enableBrazeLogging"] },
+        "secretKeys": ["restApiKey"],
+        ...
+      },
+      "configSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "required": ["restApiKey", "dataCenter"],
+        "properties": { "restApiKey": { "type": "string" }, ... }
+      },
+      "uiConfig": { "baseTemplate": [ ... ] }
+    }
+  }
+}
+```
+
+**Why single record with nested versions:**
+
+- **Backward compatible** — top-level fields remain the latest version, exactly as today. Existing consumers that don't know about versions keep working.
+- **Atomic** — all versions of an integration are one record. No cross-row consistency concerns during deploys.
+- **Minimal deploy change** — merge root files as today, then for each `versions/{major}/`, merge its three files and nest under `versions.{major}`.
+
+**How consumers read it:**
+
+- **Version-unaware consumers** (existing) — read top-level fields as before. Nothing changes.
+- **Config backend** (version-aware) — at startup, compiles AJV schemas for each version: top-level `configSchema` for the current version, `versions.{major}.configSchema` for older versions. When validating a config, it selects the compiled schema matching `configVersion`.
+- **Web app** (version-aware) — reads `versions.{major}.uiConfig` when rendering forms for an older version's config. Shows migration banner.
+- **Data plane** — does not read the definition record. It receives the config instance (already version-tagged with `configVersion`) from the config backend. The data plane dispatches to the appropriate version-tagged handler based on `configVersion`.
+
+For integrations that haven't been versioned yet, `configVersion` and `versions` are absent — they implicitly operate as `1.0`.
+
+### How It Fits Together
+
+```
+┌─────────────┐              ┌─────────────┐  ┌─────────────┐
+│   Web UI    │              │  Terraform  │  │    CLI      │
+└──────┬──────┘              └──────┬──────┘  └──────┬──────┘
+       │                            │                │
+       │                            └────────────────┘
+       │                                     │
+       │                           configVersion in body
+       │                                     │
+       │                                     ▼
+       │                           ┌──────────────────┐
+       │                           │   Public API     │
+       │                           │   (rudder-api)   │
+       │                           └────────┬─────────┘
+       │                                    │
+       │    configVersion in body           │
+       │                                    │
+       └──────────────┬─────────────────────┘
+                      │
+                      ▼
+             ┌──────────────────┐
+             │  Config Backend  │  (rudder-config-backend)
+             │  ┌────────────┐  │
+             │  │ Version    │  │  - Resolves configVersion
+             │  │ Resolution │  │  - Selects AJV schema per version
+             │  │ + AJV      │  │  - Extracts secrets
+             │  │ Validation │  │  - Migrate endpoint (read-only)
+             │  │ + Migrate  │  │  - Persists to DB
+             │  └────────────┘  │
+             └────────┬─────────┘
+                      │
+         stores config as-is with configVersion
+                      │
+             ┌────────┴─────────┐
+             ▼                  ▼
+┌──────────────────┐  ┌──────────────────┐
+│   destinations   │  │  destination_    │
+│   table          │  │  definitions     │
+│  (config +       │  │  table           │
+│   configVersion) │  │  (versions.1     │
+│                  │  │   nested blob)   │
+└──────────────────┘  └────────┬─────────┘
+                               │
+                   data plane fetches config
+                   (includes configVersion)
+                               │
+                               ▼
+                  ┌──────────────────────┐
+                  │     Data Plane       │
+                  │  (rudder-transformer)│
+                  │  dispatches to       │
+                  │  version-tagged      │
+                  │  handler             │
+                  └──────────────────────┘
+```
+
+### How `configVersion` Flows Through the System
+
+#### Current State (no versioning)
+
+Today, a destination instance is stored in the `destinations` table with `config` as a JSON column. The entity has `id`, `name`, `config`, `enabled`, `destinationDefinitionId`, `workspaceId`, `revisionId`, `secretVersion`, etc. — but no version field.
+
+The public API (`POST /v2/destinations`) accepts:
+
+```json
+{
+  "name": "my-braze",
+  "type": "BRAZE",
+  "config": { "restApiKey": "xxx", "dataCenter": "US-01" },
+  "enabled": true
+}
+```
+
+The Terraform provider transforms HCL → API payload via a `ConfigProperty` pipeline (snake_case → camelCase, array flattening, discriminators) and sends:
+
+```json
+{
+  "Type": "BRAZE",
+  "Name": "my-braze",
+  "Config": { "restApiKey": "xxx", "dataCenter": "US-01" },
+  "IsEnabled": true
+}
+```
+
+Both go to the config backend, which validates `config` against the definition's `configSchema` using AJV, extracts secrets, and persists to DB.
+
+#### With Versioning
+
+`configVersion` is a **request body field** — not a header. It travels with the payload, is easy to log/validate/store, and maps naturally to Terraform resource attributes.
+
+**Public API** (`POST /v2/destinations`):
+
+```json
+{
+  "name": "my-braze",
+  "type": "BRAZE",
+  "configVersion": 1,
+  "config": { "restApiKey": "xxx", "dataCenter": "US-01" },
+  "enabled": true
+}
+```
+
+**Config backend** stores `configVersion` alongside the config in the `destinations` table — a new column on the destination entity:
+
+```
+destinations table
+──────────────────
+id                      KSUID
+name                    string
+config                  JSON (pruned, no secrets)
+configVersion           string (nullable, default null → implicit 1)
+                        Stores resolved major.minor (e.g., "2.1")
+                        Client sends major only; config backend resolves to latest minor
+destinationDefinitionId FK
+workspaceId             FK
+revisionId              KSUID
+secretVersion           number
+enabled                 boolean
+...
+```
+
+The config backend's AJV validation selects the right compiled schema based on `configVersion`:
+
+- If `configVersion` matches a version in `versions.{major}` → validate against that version's `configSchema`
+- If `configVersion` matches the current version (or is resolved via defaulting) → validate against the top-level `configSchema`
+
+**Response** includes the resolved `configVersion` (full `major.minor`) so clients know exactly which schema was used:
+
+```json
+{
+  "id": "abc-123",
+  "name": "my-braze",
+  "type": "BRAZE",
+  "configVersion": "1.0",
+  "config": { "restApiKey": "****", "dataCenter": "US-01" },
+  "enabled": true
+}
+```
+
+#### Per-Client Behavior
+
+Terraform and CLI go through the public API (`rudder-api`), which forwards to the config backend. The web UI calls the config backend directly. All paths converge at the config backend for version resolution and validation.
+
+| Client         | Route                           | How it sends `configVersion`                                                                                                                                                                                                                                                            | Behavior                                                                                                                                                                  |
+| -------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Web UI**     | Direct → config backend         | Includes `configVersion` in request body automatically (from the definition's current version or the config's existing version)                                                                                                                                                         | Always shows latest for new configs; renders version-matched form for existing configs with migration banner                                                              |
+| **Terraform**  | Via public API → config backend | Provider includes `configVersion` in the API payload. Each destination's `ConfigMeta` registration declares which definition version it targets. The provider's `Destination` struct gains a `ConfigVersion` field, and `populateDestinationFromState()` sets it from the `ConfigMeta`. | Users don't set `configVersion` in HCL directly — it's baked into the provider version. Upgrading the provider and running `terraform plan` surfaces new required fields. |
+| **CLI**        | Via public API → config backend | Includes `configVersion` in YAML spec, sent as body field                                                                                                                                                                                                                               | Warns on deprecated versions. `rudder-cli migrate` command for interactive migration.                                                                                     |
+| **Direct API** | Via public API → config backend | Explicit `configVersion` in request body                                                                                                                                                                                                                                                | Full control. Omitting defaults to current version for new configs.                                                                                                       |
+
+#### Version Resolution
+
+When a request includes `configVersion`:
+
+- Config backend resolves the major version to the latest minor (e.g., `2` → `2.1`)
+- Validates against that version's schema
+- Stores the resolved `major.minor` in the database
+
+When `configVersion` is omitted:
+
+For **new configs** (create):
+
+- Config backend defaults to the definition's current major version (latest). Safe because there are no pre-existing field expectations.
+
+For **existing configs** (update):
+
+- Config backend preserves the stored `configVersion`. No implicit upgrade.
+
+For **existing configs with no stored `configVersion`** (pre-versioning):
+
+- All configs created before versioning was introduced have `configVersion = null` in the database. The config backend treats `null` as major version `1`. These configs continue to validate against the v1 schema until the user explicitly migrates.
+
+#### Transition Strategy
+
+When versioning is first introduced, no existing clients send `configVersion`. The rollout happens in phases:
+
+1. **Phase 1 (launch):** `configVersion` is optional. Omitting it defaults to the current version for new configs, and preserves stored version for updates. All pre-existing configs are implicitly v1. This is fully backward compatible — no client changes needed.
+
+2. **Phase 2 (adoption):** New Terraform provider and CLI versions start sending `configVersion`. Public API docs recommend including it. Web UI always sends it.
+
+3. **Phase 3 (enforcement):** After sufficient adoption, `configVersion` becomes required for the public API. Requests without it receive a deprecation warning, then eventually a validation error. This pushes remaining clients to be version-aware.
+
+The key invariant: **existing stored configs with `null` version are always treated as v1**, regardless of what the latest version is. A client that never updates its code continues to work against v1 until they explicitly migrate.
+
+---
+
+## Migration Service
+
+Migration runs as part of the existing config backend service — no new microservice needed. The migration code (JS files) lives in this repo alongside the definition it migrates.
+
+### Migration File Format
+
+The migration file only contains the transformation logic. It does not declare required inputs or preview output — those are computed by the config backend.
+
+```javascript
+// migrations/1-to-2.js
+module.exports = {
+  version: { from: 1, to: 2 },
+  description: 'Added account support, consolidated API key fields',
+
+  migrate(config) {
+    const migrated = { ...config };
+
+    // Rename
+    migrated.apiKey = migrated.restApiKey;
+    delete migrated.restApiKey;
+
+    // Add field with default
+    migrated.region = migrated.region || 'US';
+
+    // Remove deprecated field
+    delete migrated.legacyEndpoint;
+
+    return migrated;
+  },
+};
+```
+
+### How Migration Works
+
+Migration has two parts: a **read-only migrate endpoint** (used by all clients to get the migrated config) and the **normal update path** (used by all clients to persist the final config). The config backend never implicitly runs `migrate()` during a normal update — it only validates.
+
+#### Migrate Endpoint (read-only)
+
+The config backend exposes a migrate endpoint that runs `migrate()` and returns the result without persisting:
+
+```
+POST /destinations/<id>/migrate
+{ "targetVersion": 2 }
+```
+
+```javascript
+// Config backend pseudocode
+const stored = getDestination(id);
+const migration = loadMigration(stored.configVersion, targetVersion);
+const migrated = migration.migrate(cloneDeep(stored.config));
+const validation = ajv.validate(targetSchema, migrated);
+return {
+  config: migrated, // transformed config
+  validationErrors: validation.errors, // missing required fields, type mismatches
+};
+```
+
+All clients can use this endpoint to bootstrap the migrated config. The web app uses it to pre-fill the v2 form; CLI/API clients use it to get a starting point before submitting the final update.
+
+#### Update Path (persist)
+
+The normal destination update API (`PUT /destinations/<id>`) does not run `migrate()`. It simply validates the submitted config against the requested version's schema and persists:
+
+```javascript
+// Config backend pseudocode — normal update
+const schema = resolveSchema(request.configVersion); // v1 or v2 schema
+const valid = ajv.validate(schema, request.config);
+if (!valid) return { errors: ajv.errors };
+persist(id, request.config, request.configVersion);
+```
+
+The client is responsible for sending a complete, valid config for the target version. The config backend just validates and stores.
+
+### How Users Trigger Migration
+
+#### Web UI
+
+The dashboard shows a migration banner on the destination settings page when a newer version is available.
+
+1. User clicks "Upgrade to v2.0"
+2. Web app calls the **migrate endpoint** — config backend runs `migrate()` on the stored config and returns the transformed result with any validation errors
+3. Web app renders the **v2 form** (from v2 definition's `uiConfig`), pre-filled with the migrated values
+4. Fields that failed validation (e.g., missing `accountId`) are highlighted for user input
+5. User fills in the missing fields
+6. Web app submits a **normal update** with `configVersion: 2` and the full v2 config
+7. Config backend validates against v2 schema and persists
+
+#### CLI / Direct API
+
+Clients can call the migrate endpoint first to get the migrated config, then fill in any missing fields and submit a normal update:
+
+```
+# Step 1: Call migrate endpoint — returns migrated config + validation errors
+POST /v2/destinations/<id>/migrate
+{ "targetVersion": 2 }
+
+# Response:
+{
+  "config": { "apiKey": "xxx", "region": "US", "dataCenter": "US-01" },
+  "validationErrors": [{ "keyword": "required", "params": { "missingProperty": "accountId" } }]
+}
+
+# Step 2: Normal update with the full v2 config (migrated + user-supplied fields)
+PUT /v2/destinations/<id>
+{ "configVersion": 2, "config": { "apiKey": "xxx", "accountId": "abc", "region": "US", "dataCenter": "US-01" } }
+```
+
+If the client already knows the v2 schema, they can skip the migrate endpoint and send the full v2 config directly.
+
+#### Terraform
+
+The provider constructs the full v2 config from HCL — no migrate endpoint needed:
+
+1. User upgrades the Terraform provider version (which targets the new definition version)
+2. `terraform plan` shows the diff — new required fields appear as missing, removed fields show as deleted
+3. User updates their `.tf` file to match the new schema (adds `account_id`, renames `rest_api_key` → `api_key`, etc.)
+4. `terraform apply` sends a normal update with the new `configVersion` (set by the provider) and the full v2 config
+5. Config backend validates against v2 schema and persists
+
+This is the standard Terraform workflow — provider upgrades surface schema changes through `plan`/`apply`, and users adapt their configuration files accordingly.
+
+### Migration Constraints
+
+- **Forward-only** — no rollback. Users should test migrations in staging first.
+- **Chainable** — migrating from v1 to v3 runs `1-to-2.js` then `2-to-3.js` sequentially. The migrate endpoint handles this automatically.
+- **May require user input** — fields required in the target version that `migrate()` can't auto-produce are detected via schema validation and prompted to the user.
+- **Atomic** — either the full migration succeeds or nothing changes. No partial state.
+
+Note: Migration audit is not a separate concern — the existing `destinations_history` table already captures every update with `revisionId` and action type. A version change is just a normal update.
+
+---
+
+## Version Lifecycle
+
+Each definition version progresses through these states:
+
+| State          | What it means                          | What clients see                              |
+| -------------- | -------------------------------------- | --------------------------------------------- |
+| **Current**    | The recommended version for production | Default for newly created integrations.       |
+| **Supported**  | Still works, but superseded            | Fully functional. Dashboard suggests upgrade. |
+| **Deprecated** | End-of-life date announced             | Warning headers/banners on every operation.   |
+| **Retired**    | Removed from service                   | Requests rejected. Migration required.        |
+
+### Policies
+
+- At most **2 major versions** coexist at any time
+- Minimum **6 months** between deprecation announcement and retirement
+- Non-breaking bug fixes and improvements go to **all supported versions** (minor bumps)
+- **Breaking changes only go to the current version** (major bump). Older versions do not receive breaking changes — users on older versions must migrate to the latest to get the fix.
+- Deprecation is communicated through **all channels**: API `Deprecation`/`Sunset` headers per RFC 8594, dashboard banners, email to workspace admins, and changelog entries
+
+### What Triggers a Version Bump?
+
+| Change Type                        | Where it goes          | Version Impact |
+| ---------------------------------- | ---------------------- | -------------- |
+| Bug fix (non-breaking)             | All supported versions | Minor bump     |
+| Security fix (non-breaking)        | All supported versions | Minor bump     |
+| New optional field                 | Current version only   | Minor bump     |
+| New required field                 | New major version      | Major bump     |
+| Field removal/restructure          | New major version      | Major bump     |
+| Breaking fix (e.g., tighten regex) | Current version only   | Major bump     |
+
+### Breaking Changes for Older Versions
+
+If a breaking fix is needed (e.g., tightening a regex) that affects both current and older versions:
+
+- **Current version** → major bump as normal (e.g., v2.0 → v3.0)
+- **Older versions** → do **not** receive the breaking fix. Instead, users on older versions are prompted to migrate to the latest version which includes the fix.
+
+This avoids the complexity of maintaining breaking changes across old version branches, which would defeat the purpose of versioning (stable contracts for each version). If a fix is critical enough to break configs, those users should be on the latest version.
+
+Non-breaking fixes (bug fixes that don't change the contract) can still go to older versions as minor bumps.
+
+### Rollout Lifecycle
+
+#### Step 1: Introduce Breaking Change (this repo)
+
+1. Copy current root files (`db-config.json`, `ui-config.json`, `schema.json`) to `versions/1/`
+2. Add `configVersion` to `versions/1/db-config.json`: `{ "version": "1.0", "status": "supported" }`
+3. Create migration file: `migrations/1-to-2.js`
+4. Update root `db-config.json` with `configVersion`: `{ "version": "2.0", "status": "current" }`
+5. Make breaking changes to root `db-config.json`, `ui-config.json` (and regenerate `schema.json`)
+6. Deploy definitions — the deploy script merges `versions/1/` into the definition record under `versions.1`
+
+#### Step 2: Data Plane Update (transformer team)
+
+1. Data plane adds `2.0` field handling **alongside** existing `1.0` handling via version-tagged handlers (e.g., `brazeV1.process()`, `brazeV2.process()`)
+2. Router dispatches to the right handler based on `configVersion` (which the data plane receives as part of the destination config from the config backend)
+3. Deploy data plane — now handles both `1.0` and `2.0`
+
+#### Step 3: User-Triggered Migration
+
+1. Web UI shows migration banner on existing `1.0` destinations
+2. User clicks "Upgrade to v2.0" — web app calls the migrate endpoint, gets migrated config pre-filled into the v2 form, user fills in any remaining required fields, submits a normal update with `configVersion: 2`
+3. Terraform/CLI/API users construct v2 configs and submit normal updates with `configVersion: 2` at their own pace
+
+#### Step 4: Deprecation & Retirement
+
+1. After deprecation period → update `versions/1/db-config.json`'s `configVersion.status` to `"deprecated"` (warnings on every operation)
+2. After retirement date → update status to `"retired"` (requests rejected, forced migration required)
+3. Data plane drops `1.0` handling
+4. Optionally clean up `versions/1/` and `migrations/1-to-2.js`
+
+### How Validation Works Per Version
+
+```
+Client sends: { configVersion: 1, config: { restApiKey: "xxx" } }
+  → Config backend resolves 1 → latest minor "1.0"
+  → Looks up BRAZE definition, finds versions.1.configSchema
+  → Validates against v1 compiled AJV schema ✓
+  → Stores config with configVersion: "1.0" in destinations table
+  → Config remains at v1 until user explicitly migrates
+
+Client sends: { configVersion: 2, config: { apiKey: "xxx", accountId: "abc" } }
+  → Config backend resolves 2 → latest minor "2.1"
+  → Validates against top-level configSchema (current) ✓
+  → AJV applies defaults for new optional fields added in 2.1
+  → Stores config with configVersion: "2.1"
+
+Client sends: { config: { apiKey: "xxx", accountId: "abc" } }  (no version, new config)
+  → Config backend defaults to current major (2), resolves to "2.1"
+  → Validates against top-level configSchema ✓
+  → Stores config with configVersion: "2.1"
+```
+
+---
+
+## CI Guardrails
+
+The CI pipeline enforces versioning discipline automatically:
+
+1. **Break detection** — Diffs schema.json + db-config.json against the previous version. If a breaking change is detected, the PR must include a migration file and a `versions/{major}/` directory for the old version. Otherwise it fails.
+2. **Version directory integrity** — Changes to `versions/` directories must be accompanied by a minor version bump in that version's `db-config.json`.
+3. **Migration smoke tests** — Runs each migration file against a set of sample configs, then validates the output against the target version's schema. Ensures `migrate()` produces configs that pass AJV validation (with the exception of fields that require user input).
+4. **Version bookkeeping** — Checks that every `versions/{major}/` directory has a valid `configVersion` in its `db-config.json`, and that no version directory exists without being referenced.
+5. **Changelog required** — A PR that bumps a major version must include a `CHANGELOG.md` entry.
+6. **Version ceiling** — Rejects PRs that would create more than 2 simultaneously supported major versions.
+7. **Schema generation first** — Runs `schemaGenerator.py` before break detection, so the comparison uses the generated schema, not a stale one.
+
+**Important:** ui-config.json changes alone never trigger a version bump. The schema auto-generation pipeline may cause a ui-config edit to produce a schema diff, but the version decision is always based on the resulting schema.json/db-config.json change — not the ui-config.json change itself.
+
+---
+
+## Risks
+
+| What could go wrong            | How bad  | Prevention                                     | Recovery                        |
+| ------------------------------ | -------- | ---------------------------------------------- | ------------------------------- |
+| Migration corrupts config data | Critical | Atomic transactions, original config preserved | Restore from audit log          |
+| Terraform state drifts         | High     | Provider pins to supported version range       | `terraform import` with version |
+| Users confused by versions     | Medium   | Migration guides, dashboard prompts            | Support team playbook           |
+| Schema resolution slows API    | Medium   | Cache compiled schemas per version             | Horizontal scaling              |
+| Too many versions accumulate   | Low      | Hard cap of 2 major versions in CI             | Automated retirement scripts    |
+
+---
+
+## What This Unblocks
+
+| Today's Problem                  | How Versioning Solves It                                                                                        |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| **Coordinated big-bang deploys** | Config, data plane, and user migration happen independently — no synchronized release needed.                   |
+| **Breaking live configs**        | Configs stay in their original version until the user explicitly migrates. Nothing breaks silently.             |
+| **One-off migration scripts**    | Reusable migration-as-code with `migrate()`. Testable in CI, executable in config backend via migrate endpoint. |
+| **Clients fall out of sync**     | Each client (Web UI, Terraform, CLI, API) migrates on its own schedule. Version in request ensures correctness. |
+| **Account support is stuck**     | `rudderAccountId` ships as a v2 required field. v1 users keep working. v2 users provide it during migration.    |
+
+---
+
+## All Design Decisions
+
+### Architecture
+
+1. **Version within same integration** — NOT creating new v2 folders
+2. **Multi-version storage** — configs stored as-is in their original version, tagged with version
+3. **User-triggered migration** — users explicitly migrate when ready; not batch-forced
+4. **Migration via normal update API** — no implicit migration during updates. Config backend only validates and persists. All clients can use the read-only migrate endpoint to get the migrated config first, then submit a normal update with the complete v2 config.
+5. **Migration as code** — JS migration files contain only `migrate()` transform; used by the migrate endpoint to convert stored configs to target version shape
+6. **Data plane handles multiple versions** — version-tagged handlers; router dispatches by configVersion
+7. **Forward-only, chainable migrations** — v1→v2→v3; no downgrade
+8. **Integration-level versioning** — not workspace-level; each integration instance carries its own version
+9. **Semantic versioning per integration** — major.minor (clients send major only; config backend resolves to latest minor)
+10. **Destinations first** — sources can follow the same pattern once proven; connection configs (RETL) are out of scope for now
+
+### API & Client Behavior
+
+1. **`configVersion` as request body field** — clients send major version only (e.g., `2`); config backend resolves to latest minor and stores full `major.minor`
+2. **Smart defaulting** — new configs default to current version; existing configs preserve their stored version; old clients (no `configVersion`) treated as v1
+3. **Three-phase transition** — `configVersion` starts optional, becomes recommended, then required for the public API
+4. **Terraform provider version determines definition version support** — `configVersion` is set by the provider, not by users in HCL
+
+### Lifecycle & Policy
+
+1. **Max 2 major versions simultaneously**
+2. **6-month minimum deprecation notice** before retirement
+3. **Non-breaking fixes to old versions bump minor** — applied directly in `versions/{major}/`
+4. **Breaking fixes skip old versions** — users must migrate to latest to get breaking fixes; no breaking changes to old version branches
+
+### Versioning Scope
+
+1. **ui-config.json never directly triggers versioning** — only schema.json and db-config.json changes trigger version bumps
+2. **options.deprecated is separate** — whole-integration deprecation (GA→GA4) is orthogonal to version lifecycle states
+3. **Web app: version-aware editing** — renders form matching config's version, with migration banner
+
+### Infrastructure
+
+1. **Migrate endpoint in config backend** — read-only `POST /destinations/<id>/migrate` that runs `migrate()` and returns transformed config + validation errors; usable by all clients to bootstrap the migrated config before submitting a normal update
+2. **Terraform: provider blocks on version mismatch** — clear error guides user to migrate first, then upgrade provider
+3. **Deprecation: multi-channel communication** — API headers (RFC 8594) + dashboard banners + email + changelog
+4. **Definition storage: single record with nested versions** — `versions.{major}` nested in the definition record; config backend projects the right version at read time
+5. **Instance storage: `configVersion` column on `destinations` table** — nullable string; `null` = implicit major version `1`
+
+### Future
+
+1. **Schema consolidation** — merge 3 files into `definition.json` (see [schema-consolidation.md](./schema-consolidation.md))
+2. **Version discovery API** — deferred until demand arises
+
+---
+
+## Related Documents
+
+- [Change Scenario Taxonomy](./change-scenarios.md) — comprehensive catalog of 65+ change types across schema.json, db-config.json, and ui-config.json, classified as safe/breaking/conditional
+- [Schema Consolidation Proposal](./schema-consolidation.md) — future design for merging 3 files into a single `definition.json`, with a full Braze example
+- [Prior Research (Notion)](https://www.notion.so/rudderstacks/Destination-Definition-Versioning-Research-Doc-2eff2b415dd080a893e3d745c7d7b34e) — earlier exploration of versioning options and architecture


### PR DESCRIPTION
## Summary

- Adds three design documents under `docs/integrations-definition-versioning/` for the destination definition versioning framework:
  - **versioning-design.md** — Main architecture doc covering per-integration major.minor versioning, DB storage model, configVersion flow through all clients (web UI, Terraform, CLI, public API), migration service, version lifecycle, CI guardrails, and rollout transition strategy
  - **change-scenarios.md** — Taxonomy classifying all possible schema, db-config, and ui-config changes as safe, breaking, or conditional, with migration code examples
  - **schema-consolidation.md** — Future proposal to merge db-config.json + schema.json into a single definition.json using `x-` prefixed JSON Schema annotations (`x-secret`, `x-sdkVisible`, `x-sourceTypeKeyed`), eliminating schemaGenerator.py and top-level array drift
- Adds `.claude/memory` to `.gitignore`

## Test plan

- [ ] Review versioning-design.md for architectural completeness
- [ ] Review change-scenarios.md for correctness of breaking/safe classifications
- [ ] Review schema-consolidation.md for feasibility of `x-sourceTypeKeyed` approach and migration path
- [ ] Validate that the proposed definition.json structure covers all fields currently in db-config.json + schema.json