### PR TITLE
feat(lotame_mobile): deprecate lotame mobile destination

### DIFF
--- a/src/configurations/destinations/lotame_mobile/db-config.json
+++ b/src/configurations/destinations/lotame_mobile/db-config.json
@@ -1,6 +1,10 @@
 {
   "name": "LOTAME_MOBILE",
   "displayName": "Lotame Mobile",
+  "options": {
+    "deprecated": true,
+    "deprecationLabel": "Lotame Mobile is deprecated."
+  },
   "config": {
     "transformAtV1": "processor",
     "saveDestinationResponse": true,

--- a/src/configurations/destinations/lotame_mobile/schema.json
+++ b/src/configurations/destinations/lotame_mobile/schema.json
@@ -2,6 +2,7 @@
   "configSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
+    "additionalProperties": false,
     "properties": {
       "oneTrustCookieCategories": {
         "type": "object",
@@ -157,7 +158,88 @@
             }
           }
         }
+      },
+      "bcpUrlSettingsPixel": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "bcpUrlTemplate": {
+              "type": "string",
+              "pattern": "^(.{0,100})$"
+            }
+          }
+        }
+      },
+      "dspUrlSettingsPixel": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "dspUrlTemplate": {
+              "type": "string",
+              "pattern": "^(.{0,100})$"
+            }
+          }
+        }
+      },
+      "mappings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+            },
+            "value": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+            }
+          }
+        }
+      },
+      "useNativeSDK": {
+        "type": "object",
+        "properties": {
+          "android": {
+            "type": "boolean"
+          },
+          "ios": {
+            "type": "boolean"
+          }
+        }
+      },
+      "eventFilteringOption": {
+        "type": "string",
+        "enum": ["disable", "whitelistedEvents", "blacklistedEvents"],
+        "default": "disable"
+      },
+      "whitelistedEvents": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "eventName": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+            }
+          }
+        }
+      },
+      "blacklistedEvents": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "eventName": {
+              "type": "string",
+              "pattern": "(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"
+            }
+          }
+        }
       }
-    }
+    },
+    "required": []
   }
 }


### PR DESCRIPTION
## What are the changes introduced in this PR?

Deprecate the Lotame Mobile destination on the control plane by adding the `deprecated` flag and a deprecation label to its `db-config.json`.

## What is the related Linear task?

Resolves SDK-4729

## Please explain the objectives of your changes below

This PR marks the Lotame Mobile destination as deprecated so that it is no longer available for new connections on the control plane. The `options.deprecated` flag and `options.deprecationLabel` fields are added to the destination's `db-config.json`, which signals the UI to display a deprecation notice.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

Lotame Mobile destination will now show as deprecated in the RudderStack dashboard. Existing connections will continue to function, but users will see a deprecation label and will be discouraged from creating new connections.

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] I have executed schemaGenerator tests and updated schema if needed

- [x] Are sensitive fields marked as secret in definition config?

- [x] My test cases and placeholders use only masked/sample values for sensitive fields

- [x] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Lotame Mobile destination is now marked deprecated; users will see a deprecation notification.
  * New configuration options are available for URL templates, mappings, native SDK toggles, event filtering, and event allow/block lists.
  * Configuration validation tightened to disallow unspecified top-level settings, preventing unsupported or accidental fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->