### PR TITLE
chore(vuln): replace secrets inherit with explicit forwarding (SEC-162)

### DIFF
--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -14,7 +14,8 @@ jobs:
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'integrations,data-management,sdk_team'
-    secrets: inherit
+    secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 
   create-branch:
     name: Create New Branch

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -15,7 +15,8 @@ jobs:
     name: Report Code Coverage
     if: github.event_name == 'push'
     uses: ./.github/workflows/report-code-coverage.yml
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   deploy-to-dev:
     name: Deployment To Development DB

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -12,7 +12,7 @@ on:
       SLACK_RELEASE_CHANNEL_ID:
         required: true
       CODECOV_TOKEN:
-        required: true
+        required: false
   push:
     branches:
       - main

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -12,7 +12,7 @@ on:
       SLACK_RELEASE_CHANNEL_ID:
         required: true
       CODECOV_TOKEN:
-        required: false
+        required: false # report-code-coverage only runs on 'push' events, never on workflow_call
   push:
     branches:
       - main

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -2,6 +2,17 @@ name: Deploy Configurations To Production DB
 
 on:
   workflow_call:
+    secrets:
+      PROD_USERNAME:
+        required: true
+      PROD_PASSWORD:
+        required: true
+      SLACK_BOT_TOKEN:
+        required: true
+      SLACK_RELEASE_CHANNEL_ID:
+        required: true
+      CODECOV_TOKEN:
+        required: true
   push:
     branches:
       - main
@@ -16,7 +27,8 @@ jobs:
     name: Report Code Coverage
     if: github.event_name == 'push'
     uses: ./.github/workflows/report-code-coverage.yml
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   extract-version:
     name: Extract Deployment Version

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -7,7 +7,8 @@ jobs:
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'integrations,data-management,sdk_team'
-    secrets: inherit
+    secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 
   draft-new-release:
     permissions:

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -63,4 +63,8 @@ jobs:
       version: ${{ inputs.version }}
       ref: ${{ inputs.ref }}
       verbose: ${{ inputs.verbose }}
-    secrets: inherit
+    secrets:
+      API_USERNAME: ${{ secrets.API_USERNAME }}
+      API_PASSWORD: ${{ secrets.API_PASSWORD }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -7,13 +7,19 @@ jobs:
     uses: ./.github/workflows/validate-actor.yml
     with:
       team_names: 'integrations,data-management,sdk_team'
-    secrets: inherit
+    secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
 
   deploy-tag:
     needs: validate-actor
     name: Rollback Production To a Tag
     uses: ./.github/workflows/deploy-to-prod.yml
-    secrets: inherit
+    secrets:
+      PROD_USERNAME: ${{ secrets.PROD_USERNAME }}
+      PROD_PASSWORD: ${{ secrets.PROD_PASSWORD }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     # Only allow to be deployed from tags and main
     # Only allow specific actors to trigger

--- a/.github/workflows/validate-actor.yml
+++ b/.github/workflows/validate-actor.yml
@@ -7,6 +7,9 @@ on:
         description: 'Comma-separated list of team names'
         type: string
         default: 'integrations'
+    secrets:
+      RELEASE_PRIVATE_KEY:
+        required: true
 
 jobs:
   validate-actor:


### PR DESCRIPTION
## Summary
- Replace all `secrets: inherit` with explicit secret forwarding in 7 caller workflows
- Add `workflow_call.secrets` declarations to called workflows that were missing them (`validate-actor.yml`, `deploy-to-prod.yml`)
- Enforces Principle of Least Authority — each called workflow only receives the secrets it needs

## zizmor rule
`secrets-inherit` — 7 findings resolved

## Test plan
- [ ] Rollback workflow still functions (validate-actor + deploy-to-prod chain)
- [ ] Deploy to dev/prod workflows still deploy successfully
- [ ] Draft new release workflow still works
- [ ] Hotfix branch creation still works
- [ ] Manual deploy still works
- [ ] Code coverage reporting still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)