### PR TITLE
docs(schema): document account definition constraints in db-config-schema

### DIFF
--- a/src/schemas/destinations/db-config-schema.json
+++ b/src/schemas/destinations/db-config-schema.json
@@ -44,6 +44,7 @@
           "type": "object",
           "title": "Supported Account Definitions",
           "description": "Account definitionIds for the destination.",
+          "$comment": "For non-OAuth account definitions, all fields (secretFields + optionFields) must also be listed in destConfig.defaultConfig; otherwise the workspace config API will silently drop them from its response. Additionally, all secretFields must be listed in secretKeys.",
           "properties": {
             "rudderAccountId": {
               "type": "array",
@@ -281,7 +282,7 @@
           "type": "object",
           "title": "Destination Configuration",
           "description": "The parameters for the destination that the user can configure.",
-          "$comment": "This is used to display default and source type specific destination configuration in the UI.",
+          "$comment": "This is used to display default and source type specific destination configuration in the UI. The workspace config API filters its response based on the fields declared here — fields from linked account definitions that are absent from defaultConfig will be silently dropped from the API response.",
           "patternProperties": {
             "^(android|androidKotlin|ios|iosSwift|web|unity|amp|cloud|warehouse|reactnative|flutter|cordova|shopify|cloudSource|defaultConfig)$": {
               "type": "array",


### PR DESCRIPTION
## Summary
- Added `$comment` to `supportedAccountDefinitions` clarifying that for non-OAuth account definitions, all fields (`secretFields` + `optionFields`) must be listed in `destConfig.defaultConfig`, and all `secretFields` must be in `secretKeys`
- Updated `$comment` on `destConfig` to surface that the workspace config API filters its response based on fields declared there — omitting account definition fields causes silent data loss

## Test plan
- [ ] Schema comments are informational only — no functional impact to validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced validation to verify all account definition fields are properly declared and mapped in destination configurations.

* **Documentation**
  * Updated schema documentation clarifying account field filtering behavior and configuration requirements.

* **Chores**
  * Improved validation script messaging and refactored validation logic for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->