### PR TITLE
chore: cleanup tiktok audience for AMP_vdm-next feature flag

### DIFF
--- a/src/configurations/destinations/tiktok_audience/db-config.json
+++ b/src/configurations/destinations/tiktok_audience/db-config.json
@@ -23,7 +23,7 @@
     "syncBehaviours": ["mirror"],
     "transformAtV1": "router",
     "destConfig": {
-      "defaultConfig": ["advertiserId", "rudderAccountId", "isHashRequired"],
+      "defaultConfig": ["advertiserId", "rudderAccountId"],
       "warehouse": [
         "adAccountId",
         "connectionMode"

--- a/src/configurations/destinations/tiktok_audience/schema.json
+++ b/src/configurations/destinations/tiktok_audience/schema.json
@@ -6,10 +6,6 @@
     "properties": {
       "rudderAccountId": {
         "type": "string"
-      },
-      "isHashRequired": {
-        "type": "boolean",
-        "default": true
       }
     },
     "anyOf": [

--- a/src/configurations/destinations/tiktok_audience/ui-config.json
+++ b/src/configurations/destinations/tiktok_audience/ui-config.json
@@ -30,26 +30,6 @@
                           "configKey": "rudderAccountId",
                           "exists": true
                         }
-                      ],
-                      "featureFlags": [
-                        {
-                          "configKey": "AMP_vdm-next",
-                          "value": true
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "checkbox",
-                    "label": "Enable Hashing",
-                    "configKey": "isHashRequired",
-                    "default": true,
-                    "preRequisites": {
-                      "featureFlags": [
-                        {
-                          "configKey": "AMP_vdm-next",
-                          "value": false
-                        }
                       ]
                     }
                   }


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

## What are the changes introduced in this PR?

  - Updated `src/configurations/destinations/tiktok_audience/ui-config.json`.
  - Removed `featureFlags` gating tied to `AMP_vdm-next` for:
    - `advertiserId` field visibility logic
    - `isHashRequired` checkbox block

## What is the related Linear task?

- Resolves INT-6242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Removed the "Enable Hashing" option from TikTok Audience settings.
  * Removed the isHashRequired setting from the default destination configuration and schema.
  * Cleared a feature-flag prerequisite on the Advertiser ID field to simplify configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->