### PR TITLE
ci: trigger post-deployment integration tests after staging deploy

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -31,14 +31,19 @@ jobs:
     permissions: {}
     steps:
       - name: Trigger Post Deployment Tests
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
-        with:
-          token: ${{ secrets.PAT }}
-          repository: rudderlabs/rudder-client-side-test
-          event-type: post-deployment-integration-tests
-          client-payload: |-
-            {
-              "environment": "staging",
-              "ref": "${{ github.event.pull_request.head.ref }}",
-              "tags": "@integrations-config and @staging"
-            }
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            https://api.github.com/repos/rudderlabs/rudder-api-test/actions/workflows/manual.yaml/dispatches \
+            -d '{
+              "ref":"main",
+              "inputs":{
+                "environment":"staging",
+                "tag":"@custom",
+                "custom_tag":"@retl and @enterprise"
+              }
+            }'

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -28,6 +28,7 @@ jobs:
     name: Trigger Post Deployment Tests
     runs-on: ubuntu-latest
     needs: deploy
+    permissions: {}
     steps:
       - name: Trigger Post Deployment Tests
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -23,3 +23,21 @@ jobs:
       API_PASSWORD: ${{ secrets.STAGING_PASSWORD }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
+
+  trigger-post-deployment-tests:
+    name: Trigger Post Deployment Tests
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Trigger Post Deployment Tests
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.PAT }}
+          repository: rudderlabs/rudder-client-side-test
+          event-type: post-deployment-integration-tests
+          client-payload: |-
+            {
+              "environment": "staging",
+              "ref": "${{ github.event.pull_request.head.ref }}",
+              "tags": "@integrations-config and @staging"
+            }


### PR DESCRIPTION
## Summary
- Adds a \`trigger-post-deployment-tests\` job to \`deploy-to-staging.yml\` that runs after the staging DB deployment completes
- Dispatches a \`workflow_dispatch\` event to \`rudderlabs/rudder-api-test\` \`manual.yaml\` workflow with \`@retl and @enterprise\` tags to kick off post-deployment API tests on staging

## Test plan
- [ ] Merge a \`release/\` or \`hotfix-release/\` PR into \`main\` to verify the \`deploy\` job succeeds and the \`trigger-post-deployment-tests\` job runs afterward
- [ ] Confirm a new workflow run appears in \`rudderlabs/rudder-api-test\` under the \`Manual Trigger\` workflow with \`environment: staging\` and tag \`@retl and @enterprise\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced production deployment workflow with explicit secret declarations for improved security handling.
  * Added automated post-deployment integration testing to the staging environment to improve test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->