### PR TITLE
chore(vuln): scope workflow permissions to least privilege (SEC-167)

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -8,6 +8,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   check-pr-title:
     name: Check PR Title

--- a/.github/workflows/create-hotfix-branch.yml
+++ b/.github/workflows/create-hotfix-branch.yml
@@ -9,6 +9,9 @@ on:
         description: Hotfix branch name
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   validate-actor:
     uses: ./.github/workflows/validate-actor.yml
@@ -21,6 +24,8 @@ jobs:
     name: Create New Branch
     runs-on: ubuntu-latest
     needs: validate-actor
+    permissions:
+      contents: write
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   report-code-coverage:
     name: Report Code Coverage

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -22,6 +22,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   report-code-coverage:
     name: Report Code Coverage

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deployment To Staging DB

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -2,6 +2,9 @@ name: Draft New Release
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   validate-actor:
     uses: ./.github/workflows/validate-actor.yml

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -2,6 +2,9 @@ name: Rollback Production
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   validate-actor:
     uses: ./.github/workflows/validate-actor.yml

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,6 +3,9 @@ name: Code quality checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   py-scripts-lint:
     name: Check for formatting of python scripts


### PR DESCRIPTION
Remediate zizmor excessive-permissions findings (SEC-167).

actionlint: no regressions before/after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflow security by implementing explicit permission scopes across deployment, verification, and release workflows. All workflows now default to read-only access for repository contents, with selective write permissions granted only to workflows requiring branch creation or modification capabilities to support critical operational processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->