### PR TITLE
fix: update deployToDB script to consider options deletion as an update

### DIFF
--- a/scripts/deployToDB.py
+++ b/scripts/deployToDB.py
@@ -147,23 +147,17 @@ def update_diff_db(selector, persisted_by_name, item_name=None, dry_run=False, v
             diff = jsondiff.diff(
                 persisted_data, updated_data, marshal=True
             )
-            # `$delete` = keys present in DB but missing from the local file. Normally we can
-            # ignore it because the full local file is POSTed (not the diff), so missing keys
-            # fall out naturally on the server. EXCEPTION: when `$delete` is the ONLY diff key,
-            # len(diff) == 0 gates the update call off entirely — and the DB keeps the stale
-            # value forever.
-            #
-            # We care about this for `options` (typically `{isBeta: true}`): when a file
-            # intentionally removes `options`, we want that to propagate to the DB. Keep
-            # `$delete: ['options']` so the change-detection gate opens; drop other `$delete`
-            # entries as noise.
+            # If the local file has dropped `options` but the DB still has a meaningful value
+            # (typically `{isBeta: true}`), explicitly null it in the payload. Without this,
+            # jsondiff reports the removal only under `$delete` — and when `$delete` is the
+            # only diff key, the `len(diff) > 0` gate skips the update call entirely, leaving
+            # the DB with the stale value forever. Writing `options: null` produces a real
+            # diff entry, opens the gate, and the server explicitly clears the field.
             delete_fields = diff.get("$delete", None)
-            if delete_fields:
-                options_value = persisted_data.get('options')
-                if 'options' in delete_fields and options_value:
-                    diff["$delete"] = ['options']
-                else:
-                    diff.pop("$delete", None)
+            if delete_fields and 'options' in delete_fields and persisted_data.get('options'):
+                diff["options"] = None
+                updated_data["options"] = None
+            diff.pop("$delete", None)
 
             if len(diff.keys()) > 0:  # changes exist
                 status, _ = update_config_definition(

--- a/scripts/deployToDB.py
+++ b/scripts/deployToDB.py
@@ -15,6 +15,10 @@ from utils import (
 
 ALL_SELECTORS = ["destination", "source"]
 BLACK_LIST_DESTINATIONS = ["RUDDER_TEST"]
+# Top-level fields that map to nullable DB columns. Keep in sync with the DDL
+# for `destination_definitions` / `source_definitions`. See
+# `normalize_nullable_column_deletions` for why this list matters.
+NULLABLE_COLUMN_FIELDS = ("options", "uiConfig", "configSchema")
 
 
 def get_command_line_arguments():
@@ -114,6 +118,28 @@ AUTH = (USERNAME, PASSWORD)
 # UTIL METHODS
 
 
+def normalize_nullable_column_deletions(diff, persisted_data, updated_data):
+    """Convert top-level deletions of nullable DB-column fields into explicit nulls.
+
+    jsondiff reports keys removed from the local file under `$delete`. When that's
+    the only diff key, the `len(diff) > 0` gate in update_diff_db skips the API
+    call and the DB retains the stale value forever. For fields that map to
+    nullable DB columns (NULLABLE_COLUMN_FIELDS), set the field to None on both
+    the diff and the payload — producing a real diff entry, opening the gate, and
+    making the server clear the column explicitly. `$delete` is always popped
+    afterwards; other entries are ignored by design (the full local file is
+    POSTed, so missing keys fall out naturally on the server).
+
+    Mutates `diff` and `updated_data` in place.
+    """
+    delete_fields = diff.get("$delete") or []
+    for field in NULLABLE_COLUMN_FIELDS:
+        if field in delete_fields and persisted_data.get(field):
+            diff[field] = None
+            updated_data[field] = None
+    diff.pop("$delete", None)
+
+
 def update_diff_db(selector, persisted_by_name, item_name=None, dry_run=False, verbose=False):
     final_report = []
 
@@ -147,17 +173,7 @@ def update_diff_db(selector, persisted_by_name, item_name=None, dry_run=False, v
             diff = jsondiff.diff(
                 persisted_data, updated_data, marshal=True
             )
-            # If the local file has dropped `options` but the DB still has a meaningful value
-            # (typically `{isBeta: true}`), explicitly null it in the payload. Without this,
-            # jsondiff reports the removal only under `$delete` — and when `$delete` is the
-            # only diff key, the `len(diff) > 0` gate skips the update call entirely, leaving
-            # the DB with the stale value forever. Writing `options: null` produces a real
-            # diff entry, opens the gate, and the server explicitly clears the field.
-            delete_fields = diff.get("$delete", None)
-            if delete_fields and 'options' in delete_fields and persisted_data.get('options'):
-                diff["options"] = None
-                updated_data["options"] = None
-            diff.pop("$delete", None)
+            normalize_nullable_column_deletions(diff, persisted_data, updated_data)
 
             if len(diff.keys()) > 0:  # changes exist
                 status, _ = update_config_definition(

--- a/scripts/deployToDB.py
+++ b/scripts/deployToDB.py
@@ -128,7 +128,7 @@ def normalize_nullable_column_deletions(diff, persisted_data, updated_data):
     the diff and the payload — producing a real diff entry, opening the gate, and
     making the server clear the column explicitly. `$delete` is always popped
     afterwards; other entries are ignored by design (the full local file is
-    POSTed, so missing keys fall out naturally on the server).
+    posted, so missing keys fall out naturally on the server).
 
     Mutates `diff` and `updated_data` in place.
     """

--- a/scripts/deployToDB.py
+++ b/scripts/deployToDB.py
@@ -147,9 +147,23 @@ def update_diff_db(selector, persisted_by_name, item_name=None, dry_run=False, v
             diff = jsondiff.diff(
                 persisted_data, updated_data, marshal=True
             )
-            # ignore the $delete - values present in DB but missing in files. Anyways this doesn't get reflected in DB as keys are missing in files itself.
-            # Best practice is to make sure all keys are maintained in the config files irrespective of them being null.
-            diff.pop("$delete", None)
+            # `$delete` = keys present in DB but missing from the local file. Normally we can
+            # ignore it because the full local file is POSTed (not the diff), so missing keys
+            # fall out naturally on the server. EXCEPTION: when `$delete` is the ONLY diff key,
+            # len(diff) == 0 gates the update call off entirely — and the DB keeps the stale
+            # value forever.
+            #
+            # We care about this for `options` (typically `{isBeta: true}`): when a file
+            # intentionally removes `options`, we want that to propagate to the DB. Keep
+            # `$delete: ['options']` so the change-detection gate opens; drop other `$delete`
+            # entries as noise.
+            delete_fields = diff.get("$delete", None)
+            if delete_fields:
+                options_value = persisted_data.get('options')
+                if 'options' in delete_fields and options_value:
+                    diff["$delete"] = ['options']
+                else:
+                    diff.pop("$delete", None)
 
             if len(diff.keys()) > 0:  # changes exist
                 status, _ = update_config_definition(


### PR DESCRIPTION
## What are the changes introduced in this PR?

Fix `scripts/deployToDB.py` so that removing a top-level nullable-column field from a local config file (`db-config.json`, `ui-config.json`, `schema.json`) actually propagates to the control-plane DB instead of being silently ignored.

## What is the related Linear task?

Resolves INT-6056

## Please explain the objectives of your changes below

### Background

`deployToDB.py` uses `jsondiff.diff(persisted, updated, marshal=True)` to detect drift between a local file and the DB. When the local file drops a key that still exists in the DB, `jsondiff` reports it under a synthetic `$delete` key.

Previously, the script unconditionally dropped `$delete` from the computed diff:
```python
diff.pop("$delete", None)
```

Rationale at the time: the script re-POSTs the *full local file* (not the diff), so any key missing from the file naturally falls out of the DB record on the server side — no explicit `$delete` handling required.

### The bug

That reasoning breaks when `$delete` is the **only** key in the diff. The code gates the update call behind `if len(diff.keys()) > 0`, so after popping `$delete` the diff is empty, the integration is reported as "No changes detected", and no API call is made. The DB keeps the stale value forever.

This affects any nullable top-level field that maps to a DB column. The case that surfaced in practice was `options` (typically `{isBeta: true}`): once a destination shipped with `isBeta: true` and the file was later updated to remove `options`, the flag remained set on the DB indefinitely. The same bug applies to `uiConfig` and `configSchema`.

### The fix

Introduced a `NULLABLE_COLUMN_FIELDS` constant (currently `("options", "uiConfig", "configSchema")`) and a helper `normalize_nullable_column_deletions(diff, persisted_data, updated_data)`. For each field in that list that appears in `$delete` with a meaningful persisted value, the helper writes `None` to both the diff and the outgoing payload:

```python
NULLABLE_COLUMN_FIELDS = ("options", "uiConfig", "configSchema")

def normalize_nullable_column_deletions(diff, persisted_data, updated_data):
    delete_fields = diff.get("$delete") or []
    for field in NULLABLE_COLUMN_FIELDS:
        if field in delete_fields and persisted_data.get(field):
            diff[field] = None
            updated_data[field] = None
    diff.pop("$delete", None)
```

This has three effects per affected field:
1. The diff now contains a real `<field>: null` entry — so `len(diff) > 0` is true and the update API call fires.
2. The POST payload explicitly carries `"<field>": null` instead of just omitting the key — the server clears the column deterministically rather than relying on implicit drop-on-missing-key behavior.
3. The dry-run diff report shows the actual change being made, rather than a synthetic `$delete` marker.

Other `$delete` entries (fields that don't map to nullable columns we manage) continue to be unconditionally dropped — the full local file is still POSTed, so any *other* missing keys fall out naturally on the server side as they did before.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

- Integrations that intentionally remove `options`, `uiConfig`, or `configSchema` will now trigger an update API call on the next deploy (previously: silent skip).
- The outgoing payload for such integrations now carries `"<field>": null` explicitly.
- All other `$delete` scenarios are unchanged — unrelated missing keys continue to be ignored as noise.
- The list of nullable column fields is hand-maintained against the DDL and must be kept in sync if new nullable columns are added to `destination_definitions` or `source_definitions`.

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fix handling of deletions for nullable configuration fields so removal is correctly included in update payloads. Deleted nullable fields are now explicitly cleared (set to null) instead of being ignored, preventing stale values from remaining in the database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->