### PR TITLE
chore(vuln): remediate template-injection findings (SEC-251)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,16 +82,18 @@ jobs:
         env:
           API_USER: ${{ secrets.API_USERNAME }}
           API_PASSWORD: ${{ secrets.API_PASSWORD }}
+          DEPLOY_URL: ${{ inputs.deploy_url }}
         run: |
-          python scripts/deployAccountsToDB.py --no-dry-run ${{ inputs.deploy_url }}
+          python scripts/deployAccountsToDB.py --no-dry-run "$DEPLOY_URL"
         continue-on-error: false
 
       - name: Deploy Destination & Source Definitions To DB
         env:
           API_USER: ${{ secrets.API_USERNAME }}
           API_PASSWORD: ${{ secrets.API_PASSWORD }}
+          DEPLOY_URL: ${{ inputs.deploy_url }}
         run: |
-          python scripts/deployToDB.py --no-dry-run ${{ inputs.deploy_url }}
+          python scripts/deployToDB.py --no-dry-run "$DEPLOY_URL"
 
       - name: Notify Slack Channel
         id: slack

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -41,12 +41,15 @@ jobs:
           egress-policy: audit
 
       - name: Validate Production Deployment
+        env:
+          DEPLOY_URL: ${{ inputs.deploy_url }}
+          REF: ${{ inputs.ref }}
         run: |
-          if [[ "${{ inputs.deploy_url }}" == "https://api.rudderstack.com" ]]; then
-            if [[ "${{ inputs.ref }}" != "main" ]]; then
+          if [[ "$DEPLOY_URL" == "https://api.rudderstack.com" ]]; then
+            if [[ "$REF" != "main" ]]; then
               echo "❌ Error: Production deployments can only be made from the 'main' branch"
-              echo "Current branch: ${{ inputs.ref }}"
-              echo "Production URL: ${{ inputs.deploy_url }}"
+              echo "Current branch: $REF"
+              echo "Production URL: $DEPLOY_URL"
               exit 1
             fi
             echo "✅ Production deployment validation passed - deploying from main branch"


### PR DESCRIPTION
Remediates `zizmor/template-injection` findings in this repo as part of the org-wide remediation tracked in [SEC-251](https://linear.app/rudderstack/issue/SEC-251) (parent: [SEC-162](https://linear.app/rudderstack/issue/SEC-162)).

## Verification

- actionlint (syntax+expressions): green before, green after
- zizmor: all targeted findings absent post-fix; no new findings introduced
- Edits scoped to `.github/` only; no reformatting / drive-by changes

## Test plan

- [ ] CI green
- [ ] No release-tagging or workflow-trigger regression (SEC-198 class)
