### PR TITLE
feat(sprig): add device mode support for androidKotlin and iosSwift

### DIFF
--- a/src/configurations/destinations/sprig/db-config.json
+++ b/src/configurations/destinations/sprig/db-config.json
@@ -17,9 +17,9 @@
     "excludeKeys": [],
     "supportedConnectionModes": {
       "android": ["device", "cloud"],
-      "androidKotlin": ["cloud"],
+      "androidKotlin": ["device", "cloud"],
       "ios": ["device", "cloud"],
-      "iosSwift": ["cloud"],
+      "iosSwift": ["device", "cloud"],
       "web": ["device", "cloud"],
       "unity": ["cloud"],
       "amp": ["cloud"],
@@ -50,7 +50,9 @@
       "device": {
         "web": ["identify", "track"],
         "android": ["identify", "track"],
-        "ios": ["identify", "track"]
+        "androidKotlin": ["identify", "track"],
+        "ios": ["identify", "track"],
+        "iosSwift": ["identify", "track"]
       }
     },
     "destConfig": {
@@ -75,7 +77,7 @@
         "oneTrustCookieCategories",
         "ketchConsentPurposes"
       ],
-      "androidKotlin": ["connectionMode", "consentManagement"],
+      "androidKotlin": ["useNativeSDK", "connectionMode", "consentManagement"],
       "ios": [
         "useNativeSDK",
         "connectionMode",
@@ -83,7 +85,7 @@
         "oneTrustCookieCategories",
         "ketchConsentPurposes"
       ],
-      "iosSwift": ["connectionMode", "consentManagement"],
+      "iosSwift": ["useNativeSDK", "connectionMode", "consentManagement"],
       "unity": [
         "connectionMode",
         "consentManagement",

--- a/src/configurations/destinations/sprig/schema.json
+++ b/src/configurations/destinations/sprig/schema.json
@@ -13,7 +13,13 @@
           "android": {
             "type": "boolean"
           },
+          "androidKotlin": {
+            "type": "boolean"
+          },
           "ios": {
+            "type": "boolean"
+          },
+          "iosSwift": {
             "type": "boolean"
           }
         }
@@ -27,7 +33,7 @@
           },
           "androidKotlin": {
             "type": "string",
-            "enum": ["cloud"]
+            "enum": ["device", "cloud"]
           },
           "ios": {
             "type": "string",
@@ -35,7 +41,7 @@
           },
           "iosSwift": {
             "type": "string",
-            "enum": ["cloud"]
+            "enum": ["device", "cloud"]
           },
           "web": {
             "type": "string",

--- a/src/configurations/destinations/sprig/ui-config.json
+++ b/src/configurations/destinations/sprig/ui-config.json
@@ -98,7 +98,15 @@
                           "value": "device"
                         },
                         {
+                          "configKey": "connectionMode.androidKotlin",
+                          "value": "device"
+                        },
+                        {
                           "configKey": "connectionMode.ios",
+                          "value": "device"
+                        },
+                        {
+                          "configKey": "connectionMode.iosSwift",
                           "value": "device"
                         }
                       ],

--- a/test/data/validation/destinations/sprig.json
+++ b/test/data/validation/destinations/sprig.json
@@ -512,5 +512,50 @@
       ]
     },
     "result": true
+  },
+  {
+    "testTitle": "androidKotlin and iosSwift in device mode with native SDK enabled",
+    "config": {
+      "environmentId": "abcd1234",
+      "connectionMode": {
+        "androidKotlin": "device",
+        "iosSwift": "device"
+      },
+      "useNativeSDK": {
+        "androidKotlin": true,
+        "iosSwift": true
+      }
+    },
+    "result": true
+  },
+  {
+    "testTitle": "androidKotlin and iosSwift in cloud mode",
+    "config": {
+      "apiKey": "abcd1234",
+      "connectionMode": {
+        "androidKotlin": "cloud",
+        "iosSwift": "cloud"
+      },
+      "useNativeSDK": {
+        "androidKotlin": false,
+        "iosSwift": false
+      }
+    },
+    "result": true
+  },
+  {
+    "testTitle": "androidKotlin and iosSwift with invalid connection mode",
+    "config": {
+      "apiKey": "abcd1234",
+      "connectionMode": {
+        "androidKotlin": "hybrid",
+        "iosSwift": "hybrid"
+      }
+    },
+    "result": false,
+    "err": [
+      "connectionMode.androidKotlin must be equal to one of the allowed values",
+      "connectionMode.iosSwift must be equal to one of the allowed values"
+    ]
   }
 ]


### PR DESCRIPTION
## What are the changes introduced in this PR?

Adds device mode support for the Sprig destination on the new `androidKotlin` and `iosSwift` SDKs. Previously these SDKs only supported cloud mode for Sprig; this PR enables `device` as a valid connection mode alongside `cloud`, wires up the `useNativeSDK` toggle, and updates the supported source events, UI config, schema, and validation tests accordingly.

## What is the related Linear task?

Resolves SDK-4762

## Please explain the objectives of your changes below

The Sprig destination integration is being extended to the new Kotlin (`androidKotlin`) and Swift (`iosSwift`) mobile SDKs in device mode. Configuration changes:

- `db-config.json`:
  - `supportedConnectionModes.androidKotlin` and `supportedConnectionModes.iosSwift` now include `"device"` in addition to `"cloud"`.
  - `supportedSourceTypes.device` now lists `androidKotlin` and `iosSwift` with `["identify", "track"]` events (matching the existing `android` and `ios` entries).
  - `supportedMessageTypes.device` is extended to include `androidKotlin` and `iosSwift`.
  - `configurationsAccordingToSourceType.androidKotlin` and `iosSwift` now include `useNativeSDK` so that the field is surfaced for these SDKs.
- `schema.json`:
  - `useNativeSDK` properties expanded to include `androidKotlin` and `iosSwift` (boolean).
  - `connectionMode.androidKotlin` and `connectionMode.iosSwift` enums updated from `["cloud"]` to `["device", "cloud"]`.
- `ui-config.json`:
  - The visibility rule that exposes the native-SDK toggle now also fires when `connectionMode.androidKotlin` or `connectionMode.iosSwift` equals `device`.
- `test/data/validation/destinations/sprig.json`: added validation tests covering device mode + native SDK enabled, cloud mode, and an invalid connection-mode value for the new SDK identifiers.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

`androidKotlin` and `iosSwift` previously accepted only `cloud` as a connection mode for Sprig. They now also accept `device`. This is an additive change — existing cloud-mode configurations remain valid.

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

Three new test cases were added in `test/data/validation/destinations/sprig.json`:
1. `androidKotlin` and `iosSwift` in device mode with `useNativeSDK` enabled — expected to pass validation.
2. `androidKotlin` and `iosSwift` in cloud mode with `useNativeSDK` disabled — expected to pass validation.
3. `androidKotlin` and `iosSwift` with an invalid `hybrid` connection mode — expected to fail with enum errors for both fields.

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] I have executed schemaGenerator tests and updated schema if needed

- [x] Are sensitive fields marked as secret in definition config?

- [x] My test cases and placeholders use only masked/sample values for sensitive fields

- [x] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Android Kotlin and iOS Swift to support both device and cloud connection modes (previously limited to cloud only).
  * Added `useNativeSDK` configuration option for Android Kotlin and iOS Swift platforms.
  * Updated UI validation to properly handle new connection mode options.

* **Tests**
  * Added validation test cases for new platform connection configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->