### PR TITLE
chore: add dry-run mode and environment selector to manual deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,9 @@ on:
       verbose:
         type: boolean
         default: false
+      dry_run:
+        type: boolean
+        default: false
     secrets:
       API_USERNAME:
         required: true
@@ -83,8 +86,9 @@ jobs:
           API_USER: ${{ secrets.API_USERNAME }}
           API_PASSWORD: ${{ secrets.API_PASSWORD }}
           DEPLOY_URL: ${{ inputs.deploy_url }}
+          DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry-run' || '--no-dry-run' }}
         run: |
-          python scripts/deployAccountsToDB.py --no-dry-run "$DEPLOY_URL"
+          python scripts/deployAccountsToDB.py "$DRY_RUN_FLAG" "$DEPLOY_URL"
         continue-on-error: false
 
       - name: Deploy Destination & Source Definitions To DB
@@ -92,15 +96,16 @@ jobs:
           API_USER: ${{ secrets.API_USERNAME }}
           API_PASSWORD: ${{ secrets.API_PASSWORD }}
           DEPLOY_URL: ${{ inputs.deploy_url }}
+          DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry-run' || '--no-dry-run' }}
         run: |
-          python scripts/deployToDB.py --no-dry-run "$DEPLOY_URL"
+          python scripts/deployToDB.py "$DRY_RUN_FLAG" "$DEPLOY_URL"
 
       - name: Notify Slack Channel
         id: slack
         # Pinned to v2.1.1 → commit 91efab103c0de0a537f72a35f6b8cda0ee76bf0a
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
         continue-on-error: true
-        if: inputs.notify == true
+        if: inputs.notify == true && inputs.dry_run == false
         env:
           PROJECT_NAME: 'Rudder Integrations Config'
           RELEASES_URL: 'https://github.com/rudderlabs/rudder-integrations-config/releases/tag/'

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -49,12 +49,30 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Validate Production Deployment
+      - name: Validate Deployment
         env:
           ENVIRONMENT: ${{ inputs.environment }}
           DRY_RUN: ${{ inputs.dry_run }}
           REF: ${{ inputs.ref }}
+          DEV_USERNAME: ${{ secrets.DEV_USERNAME }}
+          DEV_PASSWORD: ${{ secrets.DEV_PASSWORD }}
+          STAGING_USERNAME: ${{ secrets.STAGING_USERNAME }}
+          STAGING_PASSWORD: ${{ secrets.STAGING_PASSWORD }}
+          PROD_USERNAME: ${{ secrets.PROD_USERNAME }}
+          PROD_PASSWORD: ${{ secrets.PROD_PASSWORD }}
         run: |
+          case "$ENVIRONMENT" in
+            dev)        USER_VAR=DEV_USERNAME;     PASS_VAR=DEV_PASSWORD ;;
+            staging)    USER_VAR=STAGING_USERNAME; PASS_VAR=STAGING_PASSWORD ;;
+            production) USER_VAR=PROD_USERNAME;    PASS_VAR=PROD_PASSWORD ;;
+            *)          echo "❌ Unsupported environment '$ENVIRONMENT'"; exit 1 ;;
+          esac
+          if [[ -z "${!USER_VAR}" || -z "${!PASS_VAR}" ]]; then
+            echo "❌ Missing credentials for environment '$ENVIRONMENT' (expected repo secrets $USER_VAR and $PASS_VAR)"
+            exit 1
+          fi
+          echo "✅ Credentials present for environment '$ENVIRONMENT'"
+
           if [[ "$ENVIRONMENT" == "production" && "$DRY_RUN" == "false" ]]; then
             if [[ "$REF" != "main" ]]; then
               echo "❌ Error: Production deployments can only be made from the 'main' branch"

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -6,12 +6,21 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
-      deploy_url:
-        description: 'Deploy URL'
+      environment:
+        description: 'Target environment'
         required: true
-        type: string
+        type: choice
+        options:
+          - dev
+          - staging
+          - production
+      dry_run:
+        description: 'Dry run (preview only, no changes applied)'
+        required: false
+        type: boolean
+        default: true
       notify:
-        description: 'Send Slack notification'
+        description: 'Send Slack notification (ignored when dry run is enabled)'
         required: false
         type: boolean
         default: true
@@ -42,32 +51,42 @@ jobs:
 
       - name: Validate Production Deployment
         env:
-          DEPLOY_URL: ${{ inputs.deploy_url }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          DRY_RUN: ${{ inputs.dry_run }}
           REF: ${{ inputs.ref }}
         run: |
-          if [[ "$DEPLOY_URL" == "https://api.rudderstack.com" ]]; then
+          if [[ "$ENVIRONMENT" == "production" && "$DRY_RUN" == "false" ]]; then
             if [[ "$REF" != "main" ]]; then
               echo "❌ Error: Production deployments can only be made from the 'main' branch"
               echo "Current branch: $REF"
-              echo "Production URL: $DEPLOY_URL"
               exit 1
             fi
             echo "✅ Production deployment validation passed - deploying from main branch"
           else
-            echo "ℹ️  Non-production deployment - branch validation skipped"
+            echo "ℹ️  Branch validation skipped (environment=$ENVIRONMENT, dry_run=$DRY_RUN)"
           fi
 
   deploy:
     needs: validate
     uses: ./.github/workflows/deploy.yml
     with:
-      deploy_url: ${{ inputs.deploy_url }}
+      deploy_url: >-
+        ${{ inputs.environment == 'production' && 'https://api.rudderstack.com'
+         || inputs.environment == 'staging' && 'https://api.staging.rudderlabs.com'
+         || 'https://api.dev.rudderlabs.com' }}
       notify: ${{ inputs.notify }}
       version: ${{ inputs.version }}
       ref: ${{ inputs.ref }}
       verbose: ${{ inputs.verbose }}
+      dry_run: ${{ inputs.dry_run }}
     secrets:
-      API_USERNAME: ${{ secrets.API_USERNAME }}
-      API_PASSWORD: ${{ secrets.API_PASSWORD }}
+      API_USERNAME: >-
+        ${{ inputs.environment == 'production' && secrets.PROD_USERNAME
+         || inputs.environment == 'staging' && secrets.STAGING_USERNAME
+         || secrets.DEV_USERNAME }}
+      API_PASSWORD: >-
+        ${{ inputs.environment == 'production' && secrets.PROD_PASSWORD
+         || inputs.environment == 'staging' && secrets.STAGING_PASSWORD
+         || secrets.DEV_PASSWORD }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_RELEASE_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}


### PR DESCRIPTION
## What are the changes introduced in this PR?

Reworks the `Manual Deploy Configurations` workflow to remove free-form URL entry and add a safe-by-default dry-run mode:

- **`manual-deploy.yml`**
  - Replaced the free-form `deploy_url` text input with an `environment` dropdown (`dev` / `staging` / `production`).
  - Added a `dry_run` boolean input, **defaulted to `true`** so that an accidental "Run workflow" click previews changes instead of applying them.
  - The selected environment now drives both the deploy URL and the credentials passed to `deploy.yml`, mapped to the existing repo-level secrets:
    - `dev` → `https://api.dev.rudderlabs.com`, `DEV_USERNAME` / `DEV_PASSWORD`
    - `staging` → `https://api.staging.rudderlabs.com`, `STAGING_USERNAME` / `STAGING_PASSWORD`
    - `production` → `https://api.rudderstack.com`, `PROD_USERNAME` / `PROD_PASSWORD`
  - Production "must deploy from `main`" rule now applies only to real (non-dry-run) deploys, so dry-runs from feature branches are allowed.

- **`deploy.yml`** (reusable workflow)
  - Added a `dry_run` input (default `false` to preserve existing behaviour for the dev/staging/prod automated callers).
  - The two Python deploy steps now invoke either `--dry-run` or `--no-dry-run` based on this flag.
  - Slack release notification is suppressed when `dry_run == true`.

## What is the related Linear task?

Resolves INT-6056

## Please explain the objectives of your changes below

The previous manual deploy workflow had two sharp edges: an operator had to paste the correct deploy URL by hand, and there was no preview path — every run hit the live database. This change removes both: the URL is selected from a fixed dropdown that pairs each environment with its dedicated credentials, and dry-run is the default mode, so operators must explicitly opt in to a real deploy.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

- Manual workflow input contract changed: `deploy_url` (string) is removed and replaced by `environment` (choice). Anyone with bookmarked dispatch params or scripts targeting the old `deploy_url` input will need to switch to `environment`.
- Default of `dry_run=true` means users who previously clicked "Run workflow" expecting a real deploy must now uncheck the dry-run box.
- The existing automated deploy workflows (`deploy-to-dev.yml`, `deploy-to-staging.yml`, `deploy-to-prod.yml`, and `rollback.yml`) are unchanged — `dry_run` defaults to `false` in `deploy.yml`, so their behaviour is preserved.

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.