### PR TITLE
feat: onboard custom audience destination

### DIFF
--- a/src/configurations/destinations/custom_audience/db-config.json
+++ b/src/configurations/destinations/custom_audience/db-config.json
@@ -17,7 +17,6 @@
       "defaultConfig": [
         "baseUrl",
         "authenticationType",
-        "method",
         "headers",
         "actions",
         "basicAuthUserName",
@@ -33,6 +32,10 @@
     "secretKeys": ["basicAuthPassword", "bearerToken", "apiKeyValue"]
   },
   "options": {
-    "isBeta": true
+    "isBeta": true,
+    "hidden": {
+      "featureFlagName": "AMP_custom_audience",
+      "featureFlagValue": false
+    }
   }
 }

--- a/src/configurations/destinations/custom_audience/db-config.json
+++ b/src/configurations/destinations/custom_audience/db-config.json
@@ -1,0 +1,38 @@
+{
+  "name": "CUSTOM_AUDIENCE",
+  "displayName": "Custom Audience",
+  "config": {
+    "transformAtV1": "router",
+    "syncBehaviours": ["mirror"],
+    "supportedSourceTypes": ["warehouse"],
+    "supportedMessageTypes": {
+      "cloud": ["record"]
+    },
+    "supportedConnectionModes": {
+      "warehouse": ["cloud"]
+    },
+    "isAudienceSupported": true,
+    "disableJsonMapper": true,
+    "destConfig": {
+      "defaultConfig": [
+        "baseUrl",
+        "authenticationType",
+        "method",
+        "headers",
+        "actions",
+        "basicAuthUserName",
+        "basicAuthPassword",
+        "bearerToken",
+        "apiKeyName",
+        "apiKeyValue"
+      ],
+      "warehouse": [
+        "connectionMode"
+      ]
+    },
+    "secretKeys": ["basicAuthPassword", "bearerToken", "apiKeyValue"]
+  },
+  "options": {
+    "isBeta": true
+  }
+}

--- a/src/configurations/destinations/custom_audience/db-config.json
+++ b/src/configurations/destinations/custom_audience/db-config.json
@@ -36,6 +36,9 @@
     "hidden": {
       "featureFlagName": "AMP_custom_audience",
       "featureFlagValue": false
+    },
+    "createFlow": {
+      "skipSourceSelection": true
     }
   }
 }

--- a/src/configurations/destinations/custom_audience/db-config.json
+++ b/src/configurations/destinations/custom_audience/db-config.json
@@ -24,9 +24,6 @@
         "bearerToken",
         "apiKeyName",
         "apiKeyValue"
-      ],
-      "warehouse": [
-        "connectionMode"
       ]
     },
     "secretKeys": ["basicAuthPassword", "bearerToken", "apiKeyValue"]
@@ -34,11 +31,11 @@
   "options": {
     "isBeta": true,
     "hidden": {
-      "featureFlagName": "AMP_custom_audience",
+      "featureFlagName": "AMP_enable-custom-audience",
       "featureFlagValue": false
     },
     "createFlow": {
-      "skipSourceSelection": true
+      "sourceSelectionOptional": true
     }
   }
 }

--- a/src/configurations/destinations/custom_audience/schema.json
+++ b/src/configurations/destinations/custom_audience/schema.json
@@ -2,19 +2,15 @@
   "configSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
-    "required": ["baseUrl", "authenticationType", "method", "actions"],
+    "required": ["baseUrl", "authenticationType", "actions"],
     "properties": {
       "baseUrl": {
         "type": "string",
-        "pattern": "^https?://"
+        "pattern": "^https?://.+"
       },
       "authenticationType": {
         "type": "string",
         "enum": ["noAuth", "basicAuth", "bearerToken", "apiKey"]
-      },
-      "method": {
-        "type": "string",
-        "enum": ["POST", "PUT", "PATCH", "GET", "DELETE"]
       },
       "headers": {
         "type": "array",
@@ -23,7 +19,7 @@
           "required": ["key", "value"],
           "properties": {
             "key": { "type": "string", "minLength": 1 },
-            "value": { "type": "string" }
+            "value": { "type": "string", "minLength": 1 }
           }
         }
       },
@@ -46,7 +42,7 @@
               "type": "array",
               "items": {
                 "type": "object",
-                "required": ["name"],
+                "required": ["name", "isRequired", "hashType", "isCustom"],
                 "properties": {
                   "name": { "type": "string", "minLength": 1 },
                   "isRequired": { "type": "boolean" },
@@ -61,20 +57,11 @@
           }
         }
       },
-      "basicAuthUserName": { "type": "string" },
-      "basicAuthPassword": { "type": "string" },
-      "bearerToken": { "type": "string" },
-      "apiKeyName": { "type": "string" },
-      "apiKeyValue": { "type": "string" },
-      "connectionMode": {
-        "type": "object",
-        "properties": {
-          "warehouse": {
-            "type": "string",
-            "enum": ["cloud"]
-          }
-        }
-      }
+      "basicAuthUserName": { "type": "string", "minLength": 1 },
+      "basicAuthPassword": { "type": "string", "minLength": 1 },
+      "bearerToken": { "type": "string", "minLength": 1 },
+      "apiKeyName": { "type": "string", "minLength": 1 },
+      "apiKeyValue": { "type": "string", "minLength": 1 }
     },
     "allOf": [
       {

--- a/src/configurations/destinations/custom_audience/schema.json
+++ b/src/configurations/destinations/custom_audience/schema.json
@@ -1,0 +1,109 @@
+{
+  "configSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["baseUrl", "authenticationType", "method", "actions"],
+    "properties": {
+      "baseUrl": {
+        "type": "string",
+        "pattern": "^https?://"
+      },
+      "authenticationType": {
+        "type": "string",
+        "enum": ["noAuth", "basicAuth", "bearerToken", "apiKey"]
+      },
+      "method": {
+        "type": "string",
+        "enum": ["POST", "PUT", "PATCH", "GET", "DELETE"]
+      },
+      "headers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["key", "value"],
+          "properties": {
+            "key": { "type": "string", "minLength": 1 },
+            "value": { "type": "string" }
+          }
+        }
+      },
+      "actions": {
+        "type": "object",
+        "minProperties": 1,
+        "propertyNames": { "enum": ["INSERT", "UPDATE", "DELETE"] },
+        "additionalProperties": {
+          "type": "object",
+          "required": ["requestBody", "method", "endpoint", "batchSize"],
+          "properties": {
+            "requestBody": { "type": "string", "minLength": 1 },
+            "batchSize": { "type": "number", "minimum": 1, "maximum": 5000 },
+            "method": {
+              "type": "string",
+              "enum": ["POST", "PUT", "PATCH", "GET", "DELETE"]
+            },
+            "endpoint": { "type": "string", "minLength": 1 },
+            "fields": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 },
+                  "isRequired": { "type": "boolean" },
+                  "hashType": {
+                    "type": "string",
+                    "enum": ["NONE", "SHA256", "SHA512", "MD5"]
+                  },
+                  "isCustom": { "type": "boolean" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "basicAuthUserName": { "type": "string" },
+      "basicAuthPassword": { "type": "string" },
+      "bearerToken": { "type": "string" },
+      "apiKeyName": { "type": "string" },
+      "apiKeyValue": { "type": "string" },
+      "connectionMode": {
+        "type": "object",
+        "properties": {
+          "warehouse": {
+            "type": "string",
+            "enum": ["cloud"]
+          }
+        }
+      }
+    },
+    "allOf": [
+      {
+        "if": {
+          "properties": { "authenticationType": { "const": "basicAuth" } },
+          "required": ["authenticationType"]
+        },
+        "then": {
+          "required": ["basicAuthUserName", "basicAuthPassword"]
+        }
+      },
+      {
+        "if": {
+          "properties": { "authenticationType": { "const": "bearerToken" } },
+          "required": ["authenticationType"]
+        },
+        "then": {
+          "required": ["bearerToken"]
+        }
+      },
+      {
+        "if": {
+          "properties": { "authenticationType": { "const": "apiKey" } },
+          "required": ["authenticationType"]
+        },
+        "then": {
+          "required": ["apiKeyName", "apiKeyValue"]
+        }
+      }
+    ]
+  }
+}

--- a/src/configurations/destinations/custom_audience/schema.json
+++ b/src/configurations/destinations/custom_audience/schema.json
@@ -36,7 +36,7 @@
           "required": ["requestBody", "method", "endpoint", "batchSize"],
           "properties": {
             "requestBody": { "type": "string", "minLength": 1 },
-            "batchSize": { "type": "number", "minimum": 1, "maximum": 5000 },
+            "batchSize": { "type": "integer", "minimum": 1, "maximum": 5000 },
             "method": {
               "type": "string",
               "enum": ["POST", "PUT", "PATCH", "GET", "DELETE"]

--- a/src/configurations/destinations/custom_audience/ui-config.json
+++ b/src/configurations/destinations/custom_audience/ui-config.json
@@ -1,0 +1,48 @@
+{
+  "uiConfig": {
+    "baseTemplate": [
+      {
+        "title": "Initial setup",
+        "note": "Review how this destination is set up",
+        "sections": [
+          {
+            "groups": [
+              {
+                "title": "Connection settings",
+                "note": "Update your connection settings here",
+                "icon": "settings",
+                "fields": []
+              }
+            ]
+          },
+          {
+            "groups": [
+              {
+                "title": "Connection mode",
+                "note": [
+                  "Update how you want to route events from your source to destination. ",
+                  {
+                    "text": "Get help deciding",
+                    "link": "https://www.rudderstack.com/docs/destinations/rudderstack-connection-modes/"
+                  }
+                ],
+                "icon": "sliders",
+                "fields": []
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sdkTemplate": {
+      "title": "SDK settings",
+      "note": "not visible in the ui",
+      "fields": []
+    },
+    "consentSettingsTemplate": {
+      "title": "Consent settings",
+      "note": "not visible in the ui",
+      "fields": []
+    }
+  }
+}

--- a/src/configurations/destinations/custom_audience/ui-config.json
+++ b/src/configurations/destinations/custom_audience/ui-config.json
@@ -8,10 +8,13 @@
           {
             "groups": [
               {
-                "title": "Connection settings",
-                "note": "Update your connection settings here",
                 "icon": "settings",
-                "fields": []
+                "title": "Audience delivery API configuration",
+                "fields": [
+                  {
+                    "type": "audienceDeliveryApiBuilder"
+                  }
+                ]
               }
             ]
           },

--- a/src/schemas/destinations/db-config-schema.json
+++ b/src/schemas/destinations/db-config-schema.json
@@ -690,6 +690,23 @@
           "description": "Whether the destination supports custom mappings.",
           "$comment": "This is used to display the 'Custom Mappings' tab in the UI.",
           "default": false
+        },
+        "createFlow": {
+          "type": "object",
+          "title": "Create Flow",
+          "description": "Configuration for the destination create flow.",
+          "$comment": "This hosts settings that customize the destination create flow in the UI.",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "skipSourceSelection": {
+              "type": "boolean",
+              "title": "Skip Source Selection",
+              "description": "Whether to skip the source selection step in the destination create flow.",
+              "$comment": "Allows users to skip source selection so the destination can be used to create connections in the audience flow.",
+              "default": false
+            }
+          }
         }
       }
     }

--- a/src/schemas/destinations/db-config-schema.json
+++ b/src/schemas/destinations/db-config-schema.json
@@ -699,11 +699,11 @@
           "additionalProperties": false,
           "minProperties": 1,
           "properties": {
-            "skipSourceSelection": {
+            "sourceSelectionOptional": {
               "type": "boolean",
-              "title": "Skip Source Selection",
-              "description": "Whether to skip the source selection step in the destination create flow.",
-              "$comment": "Allows users to skip source selection so the destination can be used to create connections in the audience flow.",
+              "title": "Source Selection Optional",
+              "description": "Whether the source selection step is optional in the destination create flow.",
+              "$comment": "Allows users to skip source selection so the destination can be used to create without connecting to a source.",
               "default": false
             }
           }

--- a/test/consentManagementFieldsIntegrity.test.ts
+++ b/test/consentManagementFieldsIntegrity.test.ts
@@ -35,7 +35,7 @@ describe('Consent Management Fields Integrity tests', () => {
   // under src/configuration/destinations
   // and ensure the fields oneTrustCookieCategories and ketchConsentPurposes are present
 
-  const skipDestinations = ['tiktok_audience', 'linkedin_audience'];
+  const skipDestinations = ['tiktok_audience', 'linkedin_audience', 'custom_audience'];
 
   const destDir = path.resolve('src/configurations/destinations');
   const dests = fs

--- a/test/data/validation/destinations/custom_audience.json
+++ b/test/data/validation/destinations/custom_audience.json
@@ -264,6 +264,24 @@
     "err": ["actions.INSERT.batchSize must be <= 5000"]
   },
   {
+    "testTitle": "action batchSize must be an integer",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "method": "POST",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 100.5
+        }
+      }
+    },
+    "result": false,
+    "err": ["actions.INSERT.batchSize must be integer"]
+  },
+  {
     "testTitle": "action field with invalid hashType",
     "config": {
       "baseUrl": "https://api.example.com",

--- a/test/data/validation/destinations/custom_audience.json
+++ b/test/data/validation/destinations/custom_audience.json
@@ -1,0 +1,287 @@
+[
+  {
+    "testTitle": "minimal valid config with noAuth",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "method": "POST",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{\"users\": [{{users}}]}",
+          "method": "POST",
+          "endpoint": "/v1/audiences/{{audienceId}}/users",
+          "batchSize": 1000
+        }
+      }
+    },
+    "result": true
+  },
+  {
+    "testTitle": "valid config with basicAuth",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "basicAuth",
+      "basicAuthUserName": "user",
+      "basicAuthPassword": "pass",
+      "method": "POST",
+      "headers": [{ "key": "X-Custom", "value": "foo" }],
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/insert",
+          "batchSize": 500
+        },
+        "DELETE": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/delete",
+          "batchSize": 500
+        }
+      }
+    },
+    "result": true
+  },
+  {
+    "testTitle": "valid config with bearerToken and action fields",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "bearerToken",
+      "bearerToken": "token123",
+      "method": "POST",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/insert",
+          "batchSize": 1000,
+          "fields": [
+            { "name": "email", "isRequired": true, "hashType": "SHA256", "isCustom": false },
+            { "name": "first_name", "isRequired": false, "hashType": "NONE" }
+          ]
+        }
+      }
+    },
+    "result": true
+  },
+  {
+    "testTitle": "valid config with apiKey",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "apiKey",
+      "apiKeyName": "X-API-Key",
+      "apiKeyValue": "abc123",
+      "method": "POST",
+      "actions": {
+        "UPDATE": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/update",
+          "batchSize": 2000
+        }
+      }
+    },
+    "result": true
+  },
+  {
+    "testTitle": "empty config — missing required top-level properties",
+    "config": {},
+    "result": false,
+    "err": [
+      " must have required property 'baseUrl'",
+      " must have required property 'authenticationType'",
+      " must have required property 'method'",
+      " must have required property 'actions'"
+    ]
+  },
+  {
+    "testTitle": "invalid baseUrl scheme",
+    "config": {
+      "baseUrl": "ftp://example.com",
+      "authenticationType": "noAuth",
+      "method": "POST",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": ["baseUrl must match pattern \"^https?://\""]
+  },
+  {
+    "testTitle": "invalid authenticationType enum value",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "oauth",
+      "method": "POST",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": ["authenticationType must be equal to one of the allowed values"]
+  },
+  {
+    "testTitle": "basicAuth missing required credentials",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "basicAuth",
+      "method": "POST",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": [
+      " must have required property 'basicAuthUserName'",
+      " must have required property 'basicAuthPassword'",
+      " must match \"then\" schema"
+    ]
+  },
+  {
+    "testTitle": "bearerToken auth missing token",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "bearerToken",
+      "method": "POST",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": [
+      " must have required property 'bearerToken'",
+      " must match \"then\" schema"
+    ]
+  },
+  {
+    "testTitle": "apiKey auth missing key name and value",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "apiKey",
+      "method": "POST",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": [
+      " must have required property 'apiKeyName'",
+      " must have required property 'apiKeyValue'",
+      " must match \"then\" schema"
+    ]
+  },
+  {
+    "testTitle": "actions empty object — must have at least one action",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "method": "POST",
+      "actions": {}
+    },
+    "result": false,
+    "err": ["actions must NOT have fewer than 1 properties"]
+  },
+  {
+    "testTitle": "actions key not in allowed enum",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "method": "POST",
+      "actions": {
+        "UPSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": [
+      "actions must be equal to one of the allowed values",
+      "actions property name must be valid"
+    ]
+  },
+  {
+    "testTitle": "action missing required keys",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "method": "POST",
+      "actions": {
+        "INSERT": {}
+      }
+    },
+    "result": false,
+    "err": [
+      "actions.INSERT must have required property 'requestBody'",
+      "actions.INSERT must have required property 'method'",
+      "actions.INSERT must have required property 'endpoint'",
+      "actions.INSERT must have required property 'batchSize'"
+    ]
+  },
+  {
+    "testTitle": "action batchSize out of range",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "method": "POST",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 10000
+        }
+      }
+    },
+    "result": false,
+    "err": ["actions.INSERT.batchSize must be <= 5000"]
+  },
+  {
+    "testTitle": "action field with invalid hashType",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "method": "POST",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1,
+          "fields": [{ "name": "email", "hashType": "BLAKE3" }]
+        }
+      }
+    },
+    "result": false,
+    "err": [
+      "actions.INSERT.fields.0.hashType must be equal to one of the allowed values"
+    ]
+  }
+]

--- a/test/data/validation/destinations/custom_audience.json
+++ b/test/data/validation/destinations/custom_audience.json
@@ -4,7 +4,6 @@
     "config": {
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
-      "method": "POST",
       "actions": {
         "INSERT": {
           "requestBody": "{\"users\": [{{users}}]}",
@@ -23,7 +22,6 @@
       "authenticationType": "basicAuth",
       "basicAuthUserName": "user",
       "basicAuthPassword": "pass",
-      "method": "POST",
       "headers": [{ "key": "X-Custom", "value": "foo" }],
       "actions": {
         "INSERT": {
@@ -48,7 +46,6 @@
       "baseUrl": "https://api.example.com",
       "authenticationType": "bearerToken",
       "bearerToken": "token123",
-      "method": "POST",
       "actions": {
         "INSERT": {
           "requestBody": "{}",
@@ -57,7 +54,7 @@
           "batchSize": 1000,
           "fields": [
             { "name": "email", "isRequired": true, "hashType": "SHA256", "isCustom": false },
-            { "name": "first_name", "isRequired": false, "hashType": "NONE" }
+            { "name": "first_name", "isRequired": false, "hashType": "NONE", "isCustom": false }
           ]
         }
       }
@@ -71,7 +68,6 @@
       "authenticationType": "apiKey",
       "apiKeyName": "X-API-Key",
       "apiKeyValue": "abc123",
-      "method": "POST",
       "actions": {
         "UPDATE": {
           "requestBody": "{}",
@@ -90,7 +86,6 @@
     "err": [
       " must have required property 'baseUrl'",
       " must have required property 'authenticationType'",
-      " must have required property 'method'",
       " must have required property 'actions'"
     ]
   },
@@ -99,7 +94,6 @@
     "config": {
       "baseUrl": "ftp://example.com",
       "authenticationType": "noAuth",
-      "method": "POST",
       "actions": {
         "INSERT": {
           "requestBody": "{}",
@@ -110,14 +104,30 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^https?://\""]
+    "err": ["baseUrl must match pattern \"^https?://.+\""]
+  },
+  {
+    "testTitle": "baseUrl with scheme but no host",
+    "config": {
+      "baseUrl": "https://",
+      "authenticationType": "noAuth",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": ["baseUrl must match pattern \"^https?://.+\""]
   },
   {
     "testTitle": "invalid authenticationType enum value",
     "config": {
       "baseUrl": "https://api.example.com",
       "authenticationType": "oauth",
-      "method": "POST",
       "actions": {
         "INSERT": {
           "requestBody": "{}",
@@ -135,7 +145,6 @@
     "config": {
       "baseUrl": "https://api.example.com",
       "authenticationType": "basicAuth",
-      "method": "POST",
       "actions": {
         "INSERT": {
           "requestBody": "{}",
@@ -153,11 +162,29 @@
     ]
   },
   {
+    "testTitle": "basicAuth with empty credential string",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "basicAuth",
+      "basicAuthUserName": "user",
+      "basicAuthPassword": "",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": ["basicAuthPassword must NOT have fewer than 1 characters"]
+  },
+  {
     "testTitle": "bearerToken auth missing token",
     "config": {
       "baseUrl": "https://api.example.com",
       "authenticationType": "bearerToken",
-      "method": "POST",
       "actions": {
         "INSERT": {
           "requestBody": "{}",
@@ -178,7 +205,6 @@
     "config": {
       "baseUrl": "https://api.example.com",
       "authenticationType": "apiKey",
-      "method": "POST",
       "actions": {
         "INSERT": {
           "requestBody": "{}",
@@ -196,11 +222,28 @@
     ]
   },
   {
+    "testTitle": "header value must not be empty",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "headers": [{ "key": "X-Custom", "value": "" }],
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": ["headers.0.value must NOT have fewer than 1 characters"]
+  },
+  {
     "testTitle": "actions empty object — must have at least one action",
     "config": {
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
-      "method": "POST",
       "actions": {}
     },
     "result": false,
@@ -211,7 +254,6 @@
     "config": {
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
-      "method": "POST",
       "actions": {
         "UPSERT": {
           "requestBody": "{}",
@@ -232,7 +274,6 @@
     "config": {
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
-      "method": "POST",
       "actions": {
         "INSERT": {}
       }
@@ -250,7 +291,6 @@
     "config": {
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
-      "method": "POST",
       "actions": {
         "INSERT": {
           "requestBody": "{}",
@@ -268,7 +308,6 @@
     "config": {
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
-      "method": "POST",
       "actions": {
         "INSERT": {
           "requestBody": "{}",
@@ -282,18 +321,41 @@
     "err": ["actions.INSERT.batchSize must be integer"]
   },
   {
-    "testTitle": "action field with invalid hashType",
+    "testTitle": "action field missing required properties",
     "config": {
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
-      "method": "POST",
       "actions": {
         "INSERT": {
           "requestBody": "{}",
           "method": "POST",
           "endpoint": "/x",
           "batchSize": 1,
-          "fields": [{ "name": "email", "hashType": "BLAKE3" }]
+          "fields": [{ "name": "email" }]
+        }
+      }
+    },
+    "result": false,
+    "err": [
+      "actions.INSERT.fields.0 must have required property 'isRequired'",
+      "actions.INSERT.fields.0 must have required property 'hashType'",
+      "actions.INSERT.fields.0 must have required property 'isCustom'"
+    ]
+  },
+  {
+    "testTitle": "action field with invalid hashType",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "actions": {
+        "INSERT": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1,
+          "fields": [
+            { "name": "email", "isRequired": true, "hashType": "BLAKE3", "isCustom": false }
+          ]
         }
       }
     },


### PR DESCRIPTION
## What are the changes introduced in this PR?

Adds the `CUSTOM_AUDIENCE` destination definition to `rudder-integrations-config`. This is the first piece of the new generic Custom Audience destination — a self-serve audience destination that lets users sync RudderStack audiences to any HTTP API by configuring a base URL, authentication, HTTP method/headers, and per-action (`INSERT` / `UPDATE` / `DELETE`) endpoint and request body templates.

Files in this PR:

- `src/configurations/destinations/custom_audience/db-config.json` — `CUSTOM_AUDIENCE` / "Custom Audience" definition. Warehouse-only, mirror sync, `record` message type, `cloud` connection mode, marked beta. Auth secrets (`basicAuthPassword`, `bearerToken`, `apiKeyValue`) declared in `secretKeys`.
- `src/configurations/destinations/custom_audience/schema.json` — AJV `configSchema`. Required top-level: `baseUrl`, `authenticationType`, `method`, `actions`. Per-auth requirements (`basicAuth` → user+password, `bearerToken` → token, `apiKey` → name+value) enforced via `allOf` / `if`-`then`. `actions` is a map keyed by `INSERT` / `UPDATE` / `DELETE`, each requiring `requestBody`, `method`, `endpoint`, `batchSize` (1–5000), with an optional `fields` array (`name`, `isRequired`, `hashType` ∈ `NONE` | `SHA256` | `SHA512` | `MD5`, `isCustom`).
- `src/configurations/destinations/custom_audience/ui-config.json` — bare-minimum dashboard scaffold (Connection settings + Connection mode + SDK + consent template shells with `fields: []`) so the webapp doesn't crash. Real form fields are intentionally deferred — they'll be added in a follow-up once the form spec is finalized.
- `test/data/validation/destinations/custom_audience.json` — 15 validation test cases: 4 valid (one per auth type — `noAuth`, `basicAuth`, `bearerToken`, `apiKey`) and 11 negative (missing required top-level fields, invalid `baseUrl` pattern, invalid enum values, missing auth-conditional fields, empty `actions`, disallowed action keys, missing per-action required fields, `batchSize` out of range, invalid `hashType`).
- `test/consentManagementFieldsIntegrity.test.ts` — added `custom_audience` to the existing `skipDestinations` allowlist (alongside `tiktok_audience` and `linkedin_audience`).

## What is the related Linear task?

Resolves [INT-6290](https://linear.app/rudderstack/issue/INT-6290/integrations-config-destination-definition)

Parent epic: [INT-6288](https://linear.app/rudderstack/issue/INT-6288/custom-audience-destination) — Custom Audience Destination

## Please explain the objectives of your changes below

This is task T9 in the INT-6288 implementation plan. The Custom Audience destination exists so users can ship audiences to any HTTP API without us building a native integration first. This PR delivers only the integrations-config layer — the database definition, the AJV schema, a minimal UI shell, and validation fixtures. Transformer support, config-backend preview API, and the real dashboard form land in sibling tickets.

Scope decisions worth flagging:

- **No `consentManagement` / OneTrust / Ketch fields.** Unlike other warehouse audience destinations, this destination's user-defined config has no clear pairing with native consent fields, so they're omitted from `db-config.json` and `schema.json`. The `consentSettingsTemplate` in `ui-config.json` is an empty shell. `custom_audience` is added to the existing `skipDestinations` list in `consentManagementFieldsIntegrity.test.ts` — same approach already used for `tiktok_audience` and `linkedin_audience`.
- **No `supportedAccountDefinitions`.** Authentication is fully user-supplied (base URL, headers, and per-auth-type credentials) — there is no shared account/destination split.
- **`ui-config.json` form fields are intentionally blank**. The real form requires UX design around the per-action request-body template editor and field-mapping UI; that ships in a follow-up.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

Added `'custom_audience'` to the `skipDestinations` array in `test/consentManagementFieldsIntegrity.test.ts`. This test enforces a consent-management integrity contract across all destinations; the contract doesn't fit this destination's user-defined-config model, so it's exempted using the same mechanism already applied to `tiktok_audience` and `linkedin_audience`.

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

- New: `test/data/validation/destinations/custom_audience.json` — 15 fixtures consumed by the auto-discovered `validation.test.ts` AJV-driven suite.
- Modified: `test/consentManagementFieldsIntegrity.test.ts` — added `custom_audience` to `skipDestinations`.

Local test runs: `validation.test.ts` 3316 / 3316 passing (includes the new destination definition test and the 15-case fixture); `consentManagementFieldsIntegrity.test.ts` 2380 / 2380 passing with `custom_audience` correctly skipped.

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [ ] All related docs linked with the PR?
- [x] All changes manually tested?
- [ ] Any documentation changes needed with this change?
- [x] I have executed schemaGenerator tests and updated schema if needed
- [x] Are sensitive fields marked as secret in definition config?
- [x] My test cases and placeholders use only masked/sample values for sensitive fields
- [x] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Custom Audience destination: multiple auth modes (noAuth, basic, bearer, API key), configurable actions (INSERT/UPDATE/DELETE) with batch controls, field hashing, audience support, UI setup templates, option to make source selection optional during flow creation, marked as beta and hidden behind a feature flag, cloud/warehouse usage restricted, secrets flagged, JSON mapping disabled.
* **Tests**
  * Added validation fixtures for Custom Audience and updated consent-management integrity tests to skip it.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rudderlabs/rudder-integrations-config/pull/2478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->