### PR TITLE
feat(clickhouse): add quarter partition type support

### DIFF
--- a/src/configurations/destinations/clickhouse/schema.json
+++ b/src/configurations/destinations/clickhouse/schema.json
@@ -58,7 +58,7 @@
       },
       "partitionType": {
         "type": "string",
-        "pattern": "^(day|week|month)$",
+        "pattern": "^(day|week|month|quarter)$",
         "default": "day",
         "rs-immutable": true
       },

--- a/src/configurations/destinations/clickhouse/ui-config.json
+++ b/src/configurations/destinations/clickhouse/ui-config.json
@@ -163,6 +163,10 @@
             {
               "name": "Monthly",
               "value": "month"
+            },
+            {
+              "name": "Quarterly",
+              "value": "quarter"
             }
           ],
           "defaultOption": {

--- a/test/data/validation/destinations/clickhouse.json
+++ b/test/data/validation/destinations/clickhouse.json
@@ -816,6 +816,24 @@
       "accessKey": "test-access-key"
     },
     "result": false,
-    "err": ["partitionType must match pattern \"^(day|week|month)$\""]
+    "err": ["partitionType must match pattern \"^(day|week|month|quarter)$\""]
+  },
+  {
+    "config": {
+      "host": "test-host",
+      "database": "test-database",
+      "user": "test-user",
+      "password": "test-password",
+      "port": "0000",
+      "sslMode": "disable",
+      "bucketProvider": "S3",
+      "syncFrequency": "30",
+      "partitionType": "quarter",
+      "useRudderStorage": false,
+      "bucketName": "test-bucket",
+      "accessKeyID": "test-access-key-id",
+      "accessKey": "test-access-key"
+    },
+    "result": true
   }
 ]


### PR DESCRIPTION
## What are the changes introduced in this PR?

Adds \`quarter\` as a supported partition type for ClickHouse destinations.

## Changes

- \`src/configurations/destinations/clickhouse/ui-config.json\`: Added \"Quarterly\" option (\`value: \"quarter\"\`) to the \`partitionType\` singleSelect field
- \`src/configurations/destinations/clickhouse/schema.json\`: Updated validation regex from \`^(day|week|month)\$\` to \`^(day|week|month|quarter)\$\`
- \`test/data/validation/destinations/clickhouse.json\`: Updated invalid partition type error message to reflect new pattern; added passing test case for \`partitionType: \"quarter\"\`

## What is the related Linear task?

- Resolves INT-6377