### PR TITLE
chore(release): pull main into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.155.0](https://github.com/rudderlabs/rudder-config-schema/compare/v1.154.0...v1.155.0) (2026-05-22)
+
+
+### Features
+
+* **audienceActivation:** add audienceActivation metadata for FB Cust… ([#2493](https://github.com/rudderlabs/rudder-config-schema/issues/2493)) ([0c905ea](https://github.com/rudderlabs/rudder-config-schema/commit/0c905eaa0c32e9a699a2a2caf4e12637ddc071f6))
+
 ## [1.154.0](https://github.com/rudderlabs/rudder-config-schema/compare/v1.153.0...v1.154.0) (2026-05-19)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rudder-config-schema",
-  "version": "1.154.0",
+  "version": "1.155.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rudder-config-schema",
-      "version": "1.154.0",
+      "version": "1.155.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-config-schema",
-  "version": "1.154.0",
+  "version": "1.155.0",
   "description": "",
   "main": "src/index.ts",
   "private": true,

--- a/src/configurations/destinations/fb_custom_audience/db-config.json
+++ b/src/configurations/destinations/fb_custom_audience/db-config.json
@@ -57,5 +57,27 @@
       ]
     },
     "secretKeys": ["accessToken", "appSecret"]
+  },
+  "options": {
+    "audienceActivation": {
+      "discovery": {
+        "operations": {
+          "listFields": "listFields",
+          "listAudiences": "listAudiences",
+          "setup": "setup"
+        },
+        "contextFields": ["adAccountId"]
+      },
+      "vdm": {
+        "configDefaults": {
+          "syncMode": "mirror",
+          "isHashRequired": "yes",
+          "type": "FILE_IMPORTED",
+          "subType": "MULTI_HASHES",
+          "createAudience": "no"
+        }
+      },
+      "mappingGuidance": "Map every clean identifier you have. Facebook ORs across identifiers — more mappings → higher match rate. Use field names below verbatim as `to`; they are exactly what get_audience_destination_schema returns in fields[].name.\n\nStrong (each standalone-sufficient): EMAIL, PHONE, MADID, EXTERN_ID.\n\nPII bundle (contributes only when sent TOGETHER — partial bundles add ~0 match lift): FN, LN, FI (first-initial), CT, ST, ZIP, COUNTRY, DOBY, DOBM, DOBD, GEN.\n\nSend RAW warehouse values. The integration SHA256-hashes and normalizes (email→lowercase, phone→digits-only, ZIP→trim) on send. Do NOT pre-hash. Do NOT pre-bundle the address into a single JSON column. LOOKALIKE_VALUE is only for value-based lookalike audiences — skip it for standard custom-audience syncs."
+    }
   }
 }

--- a/src/schemas/destinations/db-config-schema.json
+++ b/src/schemas/destinations/db-config-schema.json
@@ -690,6 +690,90 @@
           "description": "Whether the destination supports custom mappings.",
           "$comment": "This is used to display the 'Custom Mappings' tab in the UI.",
           "default": false
+        },
+        "audienceActivation": {
+          "type": "object",
+          "title": "Audience Activation",
+          "description": "Per-destination metadata consumed by the MCP server's audience-activation tools. Lives under `options` (alongside isBeta/hidden/etc.) because it describes how downstream tooling should treat this destination — not the destination's own config form. Two concerns: `discovery` (how to probe the downstream destination — what integrationsInfo operations exist and what config to pass) and `vdm` (how to assemble a valid VDM v2 connection — the defaults that go into the connection's destination/source config). `mappingGuidance` is shared LLM-facing prose.",
+          "additionalProperties": false,
+          "required": ["discovery", "vdm", "mappingGuidance"],
+          "properties": {
+            "discovery": {
+              "type": "object",
+              "title": "Discovery",
+              "description": "How to probe the downstream destination: which integrationsInfo operations it exposes and which destination.config fields to pass when calling them.",
+              "additionalProperties": false,
+              "required": ["operations"],
+              "properties": {
+                "operations": {
+                  "type": "object",
+                  "title": "Operations",
+                  "description": "Logical-to-physical map of integrationsInfo operations the destination supports. Keys are the LOGICAL op names the MCP refers to; values are the PHYSICAL URL suffix appended to /integrationsInfo/v1/<destName>/. Single-kind destinations use identity mappings (e.g. {listFields: 'listFields'}); destinations whose physical endpoints differ from the logical names remap accordingly.",
+                  "additionalProperties": false,
+                  "minProperties": 1,
+                  "properties": {
+                    "listFields": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "listAudiences": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "setup": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                },
+                "contextFields": {
+                  "type": "array",
+                  "title": "Context Fields",
+                  "description": "Field names lifted from destination.config and passed in the integrationsInfo proxy body's `config` (e.g. adAccountId for Facebook, advertiserId for TikTok).",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            },
+            "vdm": {
+              "type": "object",
+              "title": "VDM (v2) Creation",
+              "description": "How to assemble a valid VDM v2 connection. `configDefaults` is the per-destination form-state baseline merged into the vdmConfig sent to /setup. The connection's config.source (schedule, syncSettings) is NOT here — it is a RudderStack connection-level concern identical across destinations, owned by the MCP server as a constant.",
+              "additionalProperties": false,
+              "required": ["configDefaults"],
+              "properties": {
+                "configDefaults": {
+                  "type": "object",
+                  "title": "VDM Config Defaults",
+                  "description": "Per-destination form-state defaults merged into the vdmConfig sent to /setup. Sourced from the destination's webapp form (rudder-webapp vdmFormRegistry). MCP-internal — never surfaced to the LLM. Keys vary per destination: FB needs type/subtype; TikTok omits them."
+                }
+              }
+            },
+            "mappingGuidance": {
+              "type": "string",
+              "title": "Mapping Guidance",
+              "description": "Markdown prose surfaced via get_audience_destination_schema. Codifies the 'useful mapping' rules that the field schema alone can't express: which fields are strong vs. bundle-only, match-quality direction (OR vs. pick-best), per-destination skips. Serves both concerns; the LLM reads it as one blob."
+            }
+          }
+        },
+        "createFlow": {
+          "type": "object",
+          "title": "Create Flow",
+          "description": "Configuration for the destination create flow.",
+          "$comment": "This hosts settings that customize the destination create flow in the UI.",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "sourceSelectionOptional": {
+              "type": "boolean",
+              "title": "Source Selection Optional",
+              "description": "Whether the source selection step is optional in the destination create flow.",
+              "$comment": "Allows users to skip source selection so the destination can be used to create without connecting to a source.",
+              "default": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Merges main into develop to sync hotfix/release changes back
- Brings in commits from `main` not yet in `develop` (hotfix v1.155.0, audienceActivation metadata for FB Custom Audience)
- Resolved merge conflict in `db-config-schema.json` (added `audienceActivation` schema from main)

## Test plan
- [ ] Verify CI passes
- [ ] Confirm no unintended schema changes in db-config-schema.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audience activation support for Facebook Custom Audiences, including configurable discovery operations to retrieve and manage audience lists, customizable activation defaults and sync settings, context field requirements and mappings, and comprehensive identifier mapping guidance for proper normalization, hashing behavior, and accurate synchronization of audience data to Facebook Custom Audience destinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rudderlabs/rudder-integrations-config/pull/2497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->