### PR TITLE
fix: restrict localhost in place of baseURL

### DIFF
--- a/src/configurations/destinations/custom_audience/schema.json
+++ b/src/configurations/destinations/custom_audience/schema.json
@@ -6,7 +6,7 @@
     "properties": {
       "baseUrl": {
         "type": "string",
-        "pattern": "^https?://(?!localhost(?:[:/]|$)).+"
+        "pattern": "^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$"
       },
       "authenticationType": {
         "type": "string",

--- a/src/configurations/destinations/custom_audience/schema.json
+++ b/src/configurations/destinations/custom_audience/schema.json
@@ -6,7 +6,7 @@
     "properties": {
       "baseUrl": {
         "type": "string",
-        "pattern": "^https?://.+"
+        "pattern": "^https?://(?!localhost(?:[:/]|$)).+"
       },
       "authenticationType": {
         "type": "string",

--- a/test/data/validation/destinations/custom_audience.json
+++ b/test/data/validation/destinations/custom_audience.json
@@ -104,7 +104,7 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^https?://(?!localhost(?:[:/]|$)).+\""]
+    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
   },
   {
     "testTitle": "baseUrl with scheme but no host",
@@ -121,7 +121,7 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^https?://(?!localhost(?:[:/]|$)).+\""]
+    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
   },
   {
     "testTitle": "baseUrl pointing at localhost is rejected",
@@ -138,7 +138,7 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^https?://(?!localhost(?:[:/]|$)).+\""]
+    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
   },
   {
     "testTitle": "baseUrl pointing at localhost with port is rejected",
@@ -155,12 +155,80 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^https?://(?!localhost(?:[:/]|$)).+\""]
+    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
   },
   {
-    "testTitle": "baseUrl host containing localhost as a subdomain is allowed",
+    "testTitle": "baseUrl with localhost subdomain prefix is rejected",
     "config": {
       "baseUrl": "https://localhost.example.com",
+      "authenticationType": "noAuth",
+      "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
+  },
+  {
+    "testTitle": "baseUrl pointing at a bare IP address is rejected",
+    "config": {
+      "baseUrl": "http://127.0.0.1",
+      "authenticationType": "noAuth",
+      "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
+  },
+  {
+    "testTitle": "baseUrl pointing at an ngrok tunnel is rejected",
+    "config": {
+      "baseUrl": "https://abcd1234.ngrok.io",
+      "authenticationType": "noAuth",
+      "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
+  },
+  {
+    "testTitle": "baseUrl pointing at a .localhost host is rejected",
+    "config": {
+      "baseUrl": "http://service.localhost",
+      "authenticationType": "noAuth",
+      "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
+  },
+  {
+    "testTitle": "valid baseUrl with port and path",
+    "config": {
+      "baseUrl": "https://api.example.com:8080/v1/audiences",
       "authenticationType": "noAuth",
       "actions": {
         "insert": {

--- a/test/data/validation/destinations/custom_audience.json
+++ b/test/data/validation/destinations/custom_audience.json
@@ -104,7 +104,7 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^https?://.+\""]
+    "err": ["baseUrl must match pattern \"^https?://(?!localhost(?:[:/]|$)).+\""]
   },
   {
     "testTitle": "baseUrl with scheme but no host",
@@ -121,7 +121,57 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^https?://.+\""]
+    "err": ["baseUrl must match pattern \"^https?://(?!localhost(?:[:/]|$)).+\""]
+  },
+  {
+    "testTitle": "baseUrl pointing at localhost is rejected",
+    "config": {
+      "baseUrl": "http://localhost",
+      "authenticationType": "noAuth",
+      "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": ["baseUrl must match pattern \"^https?://(?!localhost(?:[:/]|$)).+\""]
+  },
+  {
+    "testTitle": "baseUrl pointing at localhost with port is rejected",
+    "config": {
+      "baseUrl": "http://localhost:3000/path",
+      "authenticationType": "noAuth",
+      "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": false,
+    "err": ["baseUrl must match pattern \"^https?://(?!localhost(?:[:/]|$)).+\""]
+  },
+  {
+    "testTitle": "baseUrl host containing localhost as a subdomain is allowed",
+    "config": {
+      "baseUrl": "https://localhost.example.com",
+      "authenticationType": "noAuth",
+      "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
+      }
+    },
+    "result": true
   },
   {
     "testTitle": "invalid authenticationType enum value",


### PR DESCRIPTION
## What are the changes introduced in this PR?

Tightens the `baseUrl` validation pattern in the Custom Audience destination schema to reject `localhost`, preventing destination configs from pointing the delivery API at the local loopback host.

- Pattern before: `^https?://.+`
- Pattern after: `^https?://(?!localhost(?:[:/]|$)).+`

The negative lookahead rejects `localhost` only when it's the actual host (followed by `:`, `/`, or end of string), so real hostnames that merely contain `localhost` as a subdomain still validate.

| Input | Result |
| -- | -- |
| `http://localhost` | ❌ rejected |
| `http://localhost:3000/path` | ❌ rejected |
| `https://localhost/anything` | ❌ rejected |
| `https://localhost.example.com` | ✅ allowed |
| `https://api.example.com` | ✅ allowed |

## What is the related Linear task?

Resolves [INT-6425](https://linear.app/rudderstack/issue/INT-6425/custom-audience-update-schemajson-to-restrict-localhost-from-baseurl)

## Please explain the objectives of your changes below

Custom Audience lets users configure an arbitrary HTTP `baseUrl` for audience delivery. Allowing `localhost` would let a config target the local loopback interface, which isn't a valid delivery target. This change blocks it at config-validation time.

**Scope:** `localhost` only. `127.0.0.1`, IPv6 loopback (`::1`), and private IP ranges are intentionally **not** covered by this pattern, and the pattern is case-sensitive. Broader SSRF hardening, if required, is better enforced in backend code rather than a JSON-schema regex.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

The `baseUrl` pattern is stricter than before. Existing destinations already configured with a `localhost` base URL would now fail config validation — not expected in practice since Custom Audience is a new, beta, feature-flagged destination.

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

Updated `test/data/validation/destinations/custom_audience.json`:
- Updated the two existing `baseUrl` failure cases to expect the new pattern string.
- Added 3 cases: `http://localhost` (rejected), `http://localhost:3000/path` (rejected), `https://localhost.example.com` (allowed).

`validation.test.ts` + `consentManagementFieldsIntegrity.test.ts` pass locally (5697 passed, 3 skipped).

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [ ] All related docs linked with the PR?
- [x] All changes manually tested?
- [ ] Any documentation changes needed with this change?
- [x] I have executed schemaGenerator tests and updated schema if needed
- [x] Are sensitive fields marked as secret in definition config?
- [x] My test cases and placeholders use only masked/sample values for sensitive fields
- [x] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation for custom audience base URLs with stricter security requirements and improved domain format enforcement to prevent misconfiguration and strengthen system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rudderlabs/rudder-integrations-config/pull/2500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->