### PR TITLE
feat(custom_audience): add useInsertConfig toggle and require all actions

### DIFF
--- a/src/configurations/destinations/custom_audience/schema.json
+++ b/src/configurations/destinations/custom_audience/schema.json
@@ -58,7 +58,7 @@
       },
       "actions": {
         "type": "object",
-        "minProperties": 1,
+        "required": ["insert", "update", "delete"],
         "additionalProperties": false,
         "properties": {
           "insert": { "$ref": "#/definitions/baseActionConfig" },

--- a/src/configurations/destinations/custom_audience/schema.json
+++ b/src/configurations/destinations/custom_audience/schema.json
@@ -19,6 +19,21 @@
             "isCustom": { "type": "boolean" }
           }
         }
+      },
+      "baseActionConfig": {
+        "type": "object",
+        "required": ["requestBody", "method", "endpoint", "batchSize"],
+        "additionalProperties": false,
+        "properties": {
+          "requestBody": { "type": "string", "minLength": 1 },
+          "batchSize": { "type": "integer", "minimum": 1, "maximum": 5000 },
+          "method": {
+            "type": "string",
+            "enum": ["POST", "PUT", "PATCH", "GET", "DELETE"]
+          },
+          "endpoint": { "type": "string", "minLength": 1 },
+          "fields": { "$ref": "#/definitions/fieldsArray" }
+        }
       }
     },
     "properties": {
@@ -46,21 +61,7 @@
         "minProperties": 1,
         "additionalProperties": false,
         "properties": {
-          "insert": {
-            "type": "object",
-            "required": ["requestBody", "method", "endpoint", "batchSize"],
-            "additionalProperties": false,
-            "properties": {
-              "requestBody": { "type": "string", "minLength": 1 },
-              "batchSize": { "type": "integer", "minimum": 1, "maximum": 5000 },
-              "method": {
-                "type": "string",
-                "enum": ["POST", "PUT", "PATCH", "GET", "DELETE"]
-              },
-              "endpoint": { "type": "string", "minLength": 1 },
-              "fields": { "$ref": "#/definitions/fieldsArray" }
-            }
-          },
+          "insert": { "$ref": "#/definitions/baseActionConfig" },
           "update": {
             "type": "object",
             "additionalProperties": false,
@@ -84,21 +85,7 @@
               "required": ["requestBody", "method", "endpoint", "batchSize"]
             }
           },
-          "delete": {
-            "type": "object",
-            "required": ["requestBody", "method", "endpoint", "batchSize"],
-            "additionalProperties": false,
-            "properties": {
-              "requestBody": { "type": "string", "minLength": 1 },
-              "batchSize": { "type": "integer", "minimum": 1, "maximum": 5000 },
-              "method": {
-                "type": "string",
-                "enum": ["POST", "PUT", "PATCH", "GET", "DELETE"]
-              },
-              "endpoint": { "type": "string", "minLength": 1 },
-              "fields": { "$ref": "#/definitions/fieldsArray" }
-            }
-          }
+          "delete": { "$ref": "#/definitions/baseActionConfig" }
         }
       },
       "basicAuthUserName": { "type": "string", "minLength": 1 },

--- a/src/configurations/destinations/custom_audience/schema.json
+++ b/src/configurations/destinations/custom_audience/schema.json
@@ -9,6 +9,7 @@
         "items": {
           "type": "object",
           "required": ["name", "isRequired", "hashType", "isCustom"],
+          "additionalProperties": false,
           "properties": {
             "name": { "type": "string", "minLength": 1 },
             "isRequired": { "type": "boolean" },

--- a/src/configurations/destinations/custom_audience/schema.json
+++ b/src/configurations/destinations/custom_audience/schema.json
@@ -3,6 +3,24 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": ["baseUrl", "authenticationType", "actions"],
+    "definitions": {
+      "fieldsArray": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["name", "isRequired", "hashType", "isCustom"],
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "isRequired": { "type": "boolean" },
+            "hashType": {
+              "type": "string",
+              "enum": ["NONE", "SHA256", "SHA512", "MD5"]
+            },
+            "isCustom": { "type": "boolean" }
+          }
+        }
+      }
+    },
     "properties": {
       "baseUrl": {
         "type": "string",
@@ -26,33 +44,59 @@
       "actions": {
         "type": "object",
         "minProperties": 1,
-        "propertyNames": { "enum": ["insert", "update", "delete"] },
-        "additionalProperties": {
-          "type": "object",
-          "required": ["requestBody", "method", "endpoint", "batchSize"],
-          "properties": {
-            "requestBody": { "type": "string", "minLength": 1 },
-            "batchSize": { "type": "integer", "minimum": 1, "maximum": 5000 },
-            "method": {
-              "type": "string",
-              "enum": ["POST", "PUT", "PATCH", "GET", "DELETE"]
+        "additionalProperties": false,
+        "properties": {
+          "insert": {
+            "type": "object",
+            "required": ["requestBody", "method", "endpoint", "batchSize"],
+            "additionalProperties": false,
+            "properties": {
+              "requestBody": { "type": "string", "minLength": 1 },
+              "batchSize": { "type": "integer", "minimum": 1, "maximum": 5000 },
+              "method": {
+                "type": "string",
+                "enum": ["POST", "PUT", "PATCH", "GET", "DELETE"]
+              },
+              "endpoint": { "type": "string", "minLength": 1 },
+              "fields": { "$ref": "#/definitions/fieldsArray" }
+            }
+          },
+          "update": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "useInsertConfig": { "type": "boolean" },
+              "requestBody": { "type": "string", "minLength": 1 },
+              "batchSize": { "type": "integer", "minimum": 1, "maximum": 5000 },
+              "method": {
+                "type": "string",
+                "enum": ["POST", "PUT", "PATCH", "GET", "DELETE"]
+              },
+              "endpoint": { "type": "string", "minLength": 1 },
+              "fields": { "$ref": "#/definitions/fieldsArray" }
             },
-            "endpoint": { "type": "string", "minLength": 1 },
-            "fields": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": ["name", "isRequired", "hashType", "isCustom"],
-                "properties": {
-                  "name": { "type": "string", "minLength": 1 },
-                  "isRequired": { "type": "boolean" },
-                  "hashType": {
-                    "type": "string",
-                    "enum": ["NONE", "SHA256", "SHA512", "MD5"]
-                  },
-                  "isCustom": { "type": "boolean" }
-                }
-              }
+            "if": {
+              "properties": { "useInsertConfig": { "const": true } },
+              "required": ["useInsertConfig"]
+            },
+            "then": {},
+            "else": {
+              "required": ["requestBody", "method", "endpoint", "batchSize"]
+            }
+          },
+          "delete": {
+            "type": "object",
+            "required": ["requestBody", "method", "endpoint", "batchSize"],
+            "additionalProperties": false,
+            "properties": {
+              "requestBody": { "type": "string", "minLength": 1 },
+              "batchSize": { "type": "integer", "minimum": 1, "maximum": 5000 },
+              "method": {
+                "type": "string",
+                "enum": ["POST", "PUT", "PATCH", "GET", "DELETE"]
+              },
+              "endpoint": { "type": "string", "minLength": 1 },
+              "fields": { "$ref": "#/definitions/fieldsArray" }
             }
           }
         }

--- a/test/data/validation/destinations/custom_audience.json
+++ b/test/data/validation/destinations/custom_audience.json
@@ -104,7 +104,9 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
+    "err": [
+      "baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""
+    ]
   },
   {
     "testTitle": "baseUrl with scheme but no host",
@@ -121,7 +123,9 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
+    "err": [
+      "baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""
+    ]
   },
   {
     "testTitle": "baseUrl pointing at localhost is rejected",
@@ -138,7 +142,9 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
+    "err": [
+      "baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""
+    ]
   },
   {
     "testTitle": "baseUrl pointing at localhost with port is rejected",
@@ -155,7 +161,9 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
+    "err": [
+      "baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""
+    ]
   },
   {
     "testTitle": "baseUrl with localhost subdomain prefix is rejected",
@@ -172,7 +180,9 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
+    "err": [
+      "baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""
+    ]
   },
   {
     "testTitle": "baseUrl pointing at a bare IP address is rejected",
@@ -189,7 +199,9 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
+    "err": [
+      "baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""
+    ]
   },
   {
     "testTitle": "baseUrl pointing at an ngrok tunnel is rejected",
@@ -206,7 +218,9 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
+    "err": [
+      "baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""
+    ]
   },
   {
     "testTitle": "baseUrl pointing at a .localhost host is rejected",
@@ -223,7 +237,9 @@
       }
     },
     "result": false,
-    "err": ["baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""]
+    "err": [
+      "baseUrl must match pattern \"^(https?://)(?![a-zA-Z0-9-]*\\.ngrok\\.io)(?!localhost|.*\\.localhost)([a-zA-Z0-9-]{1,63}\\.)+[a-zA-Z]{2,}(:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5]\\d{4}|[1-9]\\d{1,3}))?(/.*)?$\""
+    ]
   },
   {
     "testTitle": "valid baseUrl with port and path",
@@ -313,10 +329,7 @@
       }
     },
     "result": false,
-    "err": [
-      " must have required property 'bearerToken'",
-      " must match \"then\" schema"
-    ]
+    "err": [" must have required property 'bearerToken'", " must match \"then\" schema"]
   },
   {
     "testTitle": "apiKey auth missing key name and value",
@@ -382,10 +395,7 @@
       }
     },
     "result": false,
-    "err": [
-      "actions must be equal to one of the allowed values",
-      "actions property name must be valid"
-    ]
+    "err": ["actions must NOT have additional properties"]
   },
   {
     "testTitle": "action missing required keys",
@@ -478,8 +488,134 @@
       }
     },
     "result": false,
+    "err": ["actions.insert.fields.0.hashType must be equal to one of the allowed values"]
+  },
+  {
+    "testTitle": "update action with useInsertConfig true — standard fields not required",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/insert",
+          "batchSize": 500
+        },
+        "update": {
+          "useInsertConfig": true
+        }
+      }
+    },
+    "result": true
+  },
+  {
+    "testTitle": "update action with useInsertConfig false and all standard fields",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "actions": {
+        "update": {
+          "useInsertConfig": false,
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/update",
+          "batchSize": 1000
+        }
+      }
+    },
+    "result": true
+  },
+  {
+    "testTitle": "update action with useInsertConfig false but missing standard fields",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "actions": {
+        "update": {
+          "useInsertConfig": false
+        }
+      }
+    },
+    "result": false,
     "err": [
-      "actions.insert.fields.0.hashType must be equal to one of the allowed values"
+      "actions.update must have required property 'requestBody'",
+      "actions.update must have required property 'method'",
+      "actions.update must have required property 'endpoint'",
+      "actions.update must have required property 'batchSize'",
+      "actions.update must match \"else\" schema"
     ]
+  },
+  {
+    "testTitle": "update action without useInsertConfig must have standard fields",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "actions": {
+        "update": {}
+      }
+    },
+    "result": false,
+    "err": [
+      "actions.update must have required property 'requestBody'",
+      "actions.update must have required property 'method'",
+      "actions.update must have required property 'endpoint'",
+      "actions.update must have required property 'batchSize'",
+      "actions.update must match \"else\" schema"
+    ]
+  },
+  {
+    "testTitle": "useInsertConfig must be a boolean",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "actions": {
+        "update": {
+          "useInsertConfig": "yes",
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/update",
+          "batchSize": 1000
+        }
+      }
+    },
+    "result": false,
+    "err": ["actions.update.useInsertConfig must be boolean"]
+  },
+  {
+    "testTitle": "useInsertConfig not allowed on insert action",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "actions": {
+        "insert": {
+          "useInsertConfig": true,
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/insert",
+          "batchSize": 500
+        }
+      }
+    },
+    "result": false,
+    "err": ["actions.insert must NOT have additional properties"]
+  },
+  {
+    "testTitle": "useInsertConfig not allowed on delete action",
+    "config": {
+      "baseUrl": "https://api.example.com",
+      "authenticationType": "noAuth",
+      "actions": {
+        "delete": {
+          "useInsertConfig": true,
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/delete",
+          "batchSize": 500
+        }
+      }
+    },
+    "result": false,
+    "err": ["actions.delete must NOT have additional properties"]
   }
 ]

--- a/test/data/validation/destinations/custom_audience.json
+++ b/test/data/validation/destinations/custom_audience.json
@@ -10,6 +10,18 @@
           "method": "POST",
           "endpoint": "/v1/audiences/{{audienceId}}/users",
           "batchSize": 1000
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/update",
+          "batchSize": 500
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/delete",
+          "batchSize": 500
         }
       }
     },
@@ -28,6 +40,12 @@
           "requestBody": "{}",
           "method": "POST",
           "endpoint": "/insert",
+          "batchSize": 500
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/update",
           "batchSize": 500
         },
         "delete": {
@@ -56,6 +74,18 @@
             { "name": "email", "isRequired": true, "hashType": "SHA256", "isCustom": false },
             { "name": "first_name", "isRequired": false, "hashType": "NONE", "isCustom": false }
           ]
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/update",
+          "batchSize": 500
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/delete",
+          "batchSize": 500
         }
       }
     },
@@ -69,11 +99,23 @@
       "apiKeyName": "X-API-Key",
       "apiKeyValue": "abc123",
       "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/insert",
+          "batchSize": 500
+        },
         "update": {
           "requestBody": "{}",
           "method": "PUT",
           "endpoint": "/update",
           "batchSize": 2000
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/delete",
+          "batchSize": 500
         }
       }
     },
@@ -100,6 +142,18 @@
           "method": "POST",
           "endpoint": "/x",
           "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
         }
       }
     },
@@ -117,6 +171,18 @@
         "insert": {
           "requestBody": "{}",
           "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
           "endpoint": "/x",
           "batchSize": 1
         }
@@ -138,6 +204,18 @@
           "method": "POST",
           "endpoint": "/x",
           "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
         }
       }
     },
@@ -155,6 +233,18 @@
         "insert": {
           "requestBody": "{}",
           "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
           "endpoint": "/x",
           "batchSize": 1
         }
@@ -176,6 +266,18 @@
           "method": "POST",
           "endpoint": "/x",
           "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
         }
       }
     },
@@ -193,6 +295,18 @@
         "insert": {
           "requestBody": "{}",
           "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
           "endpoint": "/x",
           "batchSize": 1
         }
@@ -214,6 +328,18 @@
           "method": "POST",
           "endpoint": "/x",
           "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
         }
       }
     },
@@ -231,6 +357,18 @@
         "insert": {
           "requestBody": "{}",
           "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
           "endpoint": "/x",
           "batchSize": 1
         }
@@ -252,6 +390,18 @@
           "method": "POST",
           "endpoint": "/x",
           "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
         }
       }
     },
@@ -266,6 +416,18 @@
         "insert": {
           "requestBody": "{}",
           "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
           "endpoint": "/x",
           "batchSize": 1
         }
@@ -283,6 +445,18 @@
         "insert": {
           "requestBody": "{}",
           "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
           "endpoint": "/x",
           "batchSize": 1
         }
@@ -308,6 +482,18 @@
           "method": "POST",
           "endpoint": "/x",
           "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
         }
       }
     },
@@ -325,6 +511,18 @@
           "method": "POST",
           "endpoint": "/x",
           "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
         }
       }
     },
@@ -340,6 +538,18 @@
         "insert": {
           "requestBody": "{}",
           "method": "POST",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
           "endpoint": "/x",
           "batchSize": 1
         }
@@ -364,6 +574,18 @@
           "method": "POST",
           "endpoint": "/x",
           "batchSize": 1
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
         }
       }
     },
@@ -371,14 +593,18 @@
     "err": ["headers.0.value must NOT have fewer than 1 characters"]
   },
   {
-    "testTitle": "actions empty object — must have at least one action",
+    "testTitle": "actions empty object — missing all required actions",
     "config": {
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
       "actions": {}
     },
     "result": false,
-    "err": ["actions must NOT have fewer than 1 properties"]
+    "err": [
+      "actions must have required property 'insert'",
+      "actions must have required property 'update'",
+      "actions must have required property 'delete'"
+    ]
   },
   {
     "testTitle": "actions key not in allowed enum",
@@ -395,7 +621,12 @@
       }
     },
     "result": false,
-    "err": ["actions must NOT have additional properties"]
+    "err": [
+      "actions must have required property 'insert'",
+      "actions must have required property 'update'",
+      "actions must have required property 'delete'",
+      "actions must NOT have additional properties"
+    ]
   },
   {
     "testTitle": "action missing required keys",
@@ -403,7 +634,19 @@
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
       "actions": {
-        "insert": {}
+        "insert": {},
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
+        }
       }
     },
     "result": false,
@@ -425,6 +668,18 @@
           "method": "POST",
           "endpoint": "/x",
           "batchSize": 10000
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
         }
       }
     },
@@ -442,6 +697,18 @@
           "method": "POST",
           "endpoint": "/x",
           "batchSize": 100.5
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
         }
       }
     },
@@ -460,6 +727,18 @@
           "endpoint": "/x",
           "batchSize": 1,
           "fields": [{ "name": "email" }]
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
         }
       }
     },
@@ -484,6 +763,18 @@
           "fields": [
             { "name": "email", "isRequired": true, "hashType": "BLAKE3", "isCustom": false }
           ]
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/x",
+          "batchSize": 1
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/x",
+          "batchSize": 1
         }
       }
     },
@@ -504,6 +795,12 @@
         },
         "update": {
           "useInsertConfig": true
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/delete",
+          "batchSize": 500
         }
       }
     },
@@ -515,12 +812,24 @@
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
       "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/insert",
+          "batchSize": 500
+        },
         "update": {
           "useInsertConfig": false,
           "requestBody": "{}",
           "method": "PUT",
           "endpoint": "/update",
           "batchSize": 1000
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/delete",
+          "batchSize": 500
         }
       }
     },
@@ -532,8 +841,20 @@
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
       "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/insert",
+          "batchSize": 500
+        },
         "update": {
           "useInsertConfig": false
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/delete",
+          "batchSize": 500
         }
       }
     },
@@ -552,7 +873,19 @@
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
       "actions": {
-        "update": {}
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/insert",
+          "batchSize": 500
+        },
+        "update": {},
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/delete",
+          "batchSize": 500
+        }
       }
     },
     "result": false,
@@ -570,12 +903,24 @@
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
       "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/insert",
+          "batchSize": 500
+        },
         "update": {
           "useInsertConfig": "yes",
           "requestBody": "{}",
           "method": "PUT",
           "endpoint": "/update",
           "batchSize": 1000
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/delete",
+          "batchSize": 500
         }
       }
     },
@@ -594,6 +939,18 @@
           "method": "POST",
           "endpoint": "/insert",
           "batchSize": 500
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/update",
+          "batchSize": 500
+        },
+        "delete": {
+          "requestBody": "{}",
+          "method": "DELETE",
+          "endpoint": "/delete",
+          "batchSize": 500
         }
       }
     },
@@ -606,6 +963,18 @@
       "baseUrl": "https://api.example.com",
       "authenticationType": "noAuth",
       "actions": {
+        "insert": {
+          "requestBody": "{}",
+          "method": "POST",
+          "endpoint": "/insert",
+          "batchSize": 500
+        },
+        "update": {
+          "requestBody": "{}",
+          "method": "PUT",
+          "endpoint": "/update",
+          "batchSize": 500
+        },
         "delete": {
           "useInsertConfig": true,
           "requestBody": "{}",


### PR DESCRIPTION
## Summary
- Add `useInsertConfig` boolean field to `actions.update` in the custom audience config schema, allowing UPDATE actions to reuse INSERT config when set to `true`
- Restructure actions schema from shared `additionalProperties` to explicit per-action properties with `additionalProperties: false`, ensuring `useInsertConfig` is only allowed on `update` (rejected on `insert`/`delete`)
- Extract shared `baseActionConfig` definition to deduplicate `insert` and `delete` action schemas
- Make all three actions (`insert`, `update`, `delete`) mandatory — replaced `minProperties: 1` with `required: ["insert", "update", "delete"]`
- Add `additionalProperties: false` to `fieldsArray` items to reject unexpected properties

Closes INT-6430

## Test plan
- [x] All 3338 validation tests pass
- [x] Lint passes
- [x] Tests cover: `useInsertConfig: true` (fields optional), `useInsertConfig: false` (fields required), missing fields, non-boolean value, rejection on insert/delete
- [x] Tests updated to provide all three actions, error expectations updated for empty/invalid actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)