### PR TITLE
ci(release): create GitHub release via gh with CHANGELOG notes

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -67,7 +67,6 @@ jobs:
           HUSKY: 0
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
           RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           REPO: ${{ github.repository }}
@@ -87,10 +86,14 @@ jobs:
             -f ref="refs/tags/v${RELEASE_VERSION}" \
             -f sha="$TAG_SHA"
 
-          # Fetch the new tag locally for conventional-github-releaser
-          git fetch --tags origin
-
-          npm run release:github
+          # Create the GitHub release with notes sliced from CHANGELOG.md.
+          # Use explicit tag + repo so the release always matches the tag we
+          # just created and lands on this repo (avoids conventional-github-releaser
+          # inferring a stale version from tag history or the wrong repo from package.json).
+          gh release create "v${RELEASE_VERSION}" \
+            --repo "${REPO}" \
+            --title "v${RELEASE_VERSION}" \
+            --notes "$(awk -v v="${RELEASE_VERSION}" '$0 ~ "^## \\["v"\\]"{f=1;next} /^## \[/{if(f)exit} f' CHANGELOG.md)"
           echo "DATE=$(date)" >> $GITHUB_ENV
 
       - name: Pull Changes Into develop Branch

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -93,7 +93,7 @@ jobs:
           gh release create "v${RELEASE_VERSION}" \
             --repo "${REPO}" \
             --title "v${RELEASE_VERSION}" \
-            --notes "$(awk -v v="${RELEASE_VERSION}" '$0 ~ "^## \\["v"\\]"{f=1;next} /^## \[/{if(f)exit} f' CHANGELOG.md)"
+            --notes "$(awk -v v="${RELEASE_VERSION}" '$0 ~ "^#+ \\["v"\\]"{f=1;next} /^#+ \[/{if(f)exit} f' CHANGELOG.md)"
           echo "DATE=$(date)" >> $GITHUB_ENV
 
       - name: Pull Changes Into develop Branch

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -71,6 +71,14 @@ jobs:
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           REPO: ${{ github.repository }}
         run: |
+          # Validate RELEASE_VERSION (derived from the branch name) is SemVer before
+          # interpolating it into tag/release names and shell arguments. Fail fast on
+          # a malformed branch name rather than creating an invalid tag/release.
+          if ! [[ "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid RELEASE_VERSION '${RELEASE_VERSION}' (expected SemVer x.y.z)"
+            exit 1
+          fi
+
           # Create annotated tag object via GitHub API (matching original git tag -a behavior)
           TAG_SHA=$(gh api "repos/${REPO}/git/tags" \
             --method POST \
@@ -86,6 +94,14 @@ jobs:
             -f ref="refs/tags/v${RELEASE_VERSION}" \
             -f sha="$TAG_SHA"
 
+          # Slice the CHANGELOG section for this version. The `^#+ \[` pattern matches
+          # both "## [x.y.z]" (minor/major) and "### [x.y.z]" (patch) headings.
+          RELEASE_NOTES="$(awk -v v="${RELEASE_VERSION}" '$0 ~ "^#+ \\["v"\\]"{f=1;next} /^#+ \[/{if(f)exit} f' CHANGELOG.md)"
+          if [[ -z "${RELEASE_NOTES//[[:space:]]/}" ]]; then
+            echo "::error::No CHANGELOG section found for v${RELEASE_VERSION}"
+            exit 1
+          fi
+
           # Create the GitHub release with notes sliced from CHANGELOG.md.
           # Use explicit tag + repo so the release always matches the tag we
           # just created and lands on this repo (avoids conventional-github-releaser
@@ -93,7 +109,7 @@ jobs:
           gh release create "v${RELEASE_VERSION}" \
             --repo "${REPO}" \
             --title "v${RELEASE_VERSION}" \
-            --notes "$(awk -v v="${RELEASE_VERSION}" '$0 ~ "^#+ \\["v"\\]"{f=1;next} /^#+ \[/{if(f)exit} f' CHANGELOG.md)"
+            --notes "${RELEASE_NOTES}"
           echo "DATE=$(date)" >> $GITHUB_ENV
 
       - name: Pull Changes Into develop Branch


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

## What are the changes introduced in this PR?

Replace conventional-github-releaser with `gh release create` using the explicit tag and repository. conventional-github-releaser inferred the version from tag history (causing an off-by-one release) and the repo from package.json (posting to the renamed rudder-config-schema). Using gh with RELEASE_VERSION + the repo ensures the release matches the created tag and lands on the correct repository. Release notes are sliced from CHANGELOG.md.

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new checks got introduced or modified in test suites. Please explain the changes.

N/A

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] I have executed schemaGenerator tests and updated schema if needed

- [ ] Are sensitive fields marked as secret in definition config?

- [ ] My test cases and placeholders use only masked/sample values for sensitive fields

- [ ] Is the PR limited to 10 file changes & one task?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release publishing workflow: validates the release version format, constructs annotated tags, and creates GitHub releases directly.
  * Release notes are now extracted from CHANGELOG entries and release creation fails if matching notes are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->