### PR TITLE
feat(bigquery): rETL BigQuery source account management (DEX-374, APL-399, APL-398)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thanks for taking the time and for your help in improving this project!
 ## Table of contents
 
 - [**RudderStack Contributor Agreement**](#rudderstack-contributor-agreement)
+- [**Conventions**](#conventions)
 - [**UI Configuration Development Requirements**](#ui-configuration-development-requirements)
 - [**How you can contribute to RudderStack**](#how-you-can-contribute-to-rudderstack)
 - [**Committing**](#committing)
@@ -13,6 +14,10 @@ Thanks for taking the time and for your help in improving this project!
 ## RudderStack Contributor Agreement
 
 To contribute to this project, we need you to sign the [**Contributor License Agreement ("CLA")**][CLA] for the first commit you make. By agreeing to the [**CLA**][CLA], we can add you to list of approved contributors and review the changes proposed by you.
+
+## Conventions
+
+Before adding new configurations, please review the repository [**conventions**](/CONVENTIONS.md). In particular, account definition names (`accountDefinitionName`) must follow the documented `SCREAMING_SNAKE_CASE` `{CATEGORY}_{TYPE}[_{AUTH_QUALIFIER}]` naming pattern.
 
 ## UI Configuration Development Requirements
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,38 @@
+# Conventions
+
+This document captures naming and structural conventions used across this repository. Following them keeps account definitions, sources, and destinations consistent and machine-validatable.
+
+## Table of contents
+
+- [**AccountDefinition naming (`accountDefinitionName`)**](#accountdefinition-naming-accountdefinitionname)
+
+## AccountDefinition naming (`accountDefinitionName`)
+
+Every account definition is identified by a unique `name` (the `accountDefinitionName`). It MUST be written in `SCREAMING_SNAKE_CASE` and follow this pattern:
+
+```
+{CATEGORY}_{TYPE}[_{AUTH_QUALIFIER}]
+```
+
+The `[_{AUTH_QUALIFIER}]` segment is optional — include it only when it is needed to disambiguate authentication variants of the same integration.
+
+### Segments
+
+| Segment            | Required | Description                                                                                                                                                             |
+| ------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CATEGORY`         | Yes      | The kind of integration the account belongs to. One of `SOURCE` or `DESTINATION`.                                                                                       |
+| `TYPE`             | Yes      | The integration key in `SCREAMING_SNAKE_CASE` (the uppercase form of the integration `type`), e.g. `BIGQUERY`, `HUBSPOT`, `SALESFORCE`, `FACEBOOK_LEAD_ADS_NATIVE`.     |
+| `AUTH_QUALIFIER`   | No       | A qualifier describing the authentication / credential variant, e.g. `OAUTH`, `NATIVE_OAUTH`. Use it to distinguish multiple account definitions for the same integration. |
+
+### Examples
+
+| `accountDefinitionName`                  | Category    | Type                       | Auth qualifier  |
+| ---------------------------------------- | ----------- | -------------------------- | --------------- |
+| `SOURCE_BIGQUERY`                        | SOURCE      | `bigquery`                 | _(none)_        |
+| `SOURCE_FACEBOOK_LEAD_ADS_NATIVE_OAUTH`  | SOURCE      | `facebook_lead_ads_native` | `OAUTH`         |
+| `DESTINATION_HUBSPOT_OAUTH`              | DESTINATION | `hubspot`                  | `OAUTH`         |
+| `DESTINATION_SALESFORCE_OAUTH`           | DESTINATION | `salesforce`               | `OAUTH`         |
+
+### Enforcement
+
+The `name` field is validated against the pattern `^[A-Z0-9_]+$` defined in [`src/schemas/account/account-db-config-schema.json`](src/schemas/account/account-db-config-schema.json). This pattern restricts names to uppercase letters, digits, and underscores, but does not by itself enforce full `SCREAMING_SNAKE_CASE` (for example, it does not prevent leading, trailing, or doubled underscores). The `{CATEGORY}_{TYPE}[_{AUTH_QUALIFIER}]` segment structure above is a convention contributors are expected to follow, not something the regex enforces.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -10,7 +10,7 @@ This document captures naming and structural conventions used across this reposi
 
 Every account definition is identified by a unique `name` (the `accountDefinitionName`). It MUST be written in `SCREAMING_SNAKE_CASE` and follow this pattern:
 
-```
+```text
 {CATEGORY}_{TYPE}[_{AUTH_QUALIFIER}]
 ```
 

--- a/src/configurations/sources/bigquery/accounts/SOURCE_BIGQUERY/db-config.json
+++ b/src/configurations/sources/bigquery/accounts/SOURCE_BIGQUERY/db-config.json
@@ -1,0 +1,10 @@
+{
+  "name": "SOURCE_BIGQUERY",
+  "type": "bigquery",
+  "category": "source",
+  "authenticationType": "service_account_key",
+  "config": {
+    "optionFields": ["project", "location"],
+    "secretFields": ["credentials"]
+  }
+}

--- a/src/configurations/sources/bigquery/accounts/SOURCE_BIGQUERY/db-config.json
+++ b/src/configurations/sources/bigquery/accounts/SOURCE_BIGQUERY/db-config.json
@@ -4,7 +4,7 @@
   "category": "source",
   "authenticationType": "service_account_key",
   "config": {
-    "optionFields": ["project", "location"],
+    "optionFields": ["projectId", "location"],
     "secretFields": ["credentials"]
   }
 }

--- a/src/configurations/sources/bigquery/accounts/SOURCE_BIGQUERY/schema.json
+++ b/src/configurations/sources/bigquery/accounts/SOURCE_BIGQUERY/schema.json
@@ -2,9 +2,9 @@
   "optionsSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
-    "required": ["project"],
+    "required": ["projectId"],
     "properties": {
-      "project": {
+      "projectId": {
         "type": "string",
         "description": "GCP project ID"
       },

--- a/src/configurations/sources/bigquery/accounts/SOURCE_BIGQUERY/schema.json
+++ b/src/configurations/sources/bigquery/accounts/SOURCE_BIGQUERY/schema.json
@@ -1,0 +1,29 @@
+{
+  "optionsSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["project"],
+    "properties": {
+      "project": {
+        "type": "string",
+        "description": "GCP project ID"
+      },
+      "location": {
+        "type": "string",
+        "description": "BigQuery dataset location (e.g., US, EU)"
+      }
+    }
+  },
+  "secretSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["credentials"],
+    "properties": {
+      "credentials": {
+        "type": "string",
+        "pattern": "^[\\s\\S]+$",
+        "description": "GCP service account key JSON"
+      }
+    }
+  }
+}

--- a/src/configurations/sources/bigquery/accounts/SOURCE_BIGQUERY/schema.json
+++ b/src/configurations/sources/bigquery/accounts/SOURCE_BIGQUERY/schema.json
@@ -6,6 +6,7 @@
     "properties": {
       "projectId": {
         "type": "string",
+        "pattern": "^[a-z][a-z0-9.:-]{4,28}[a-z0-9]$",
         "description": "GCP project ID"
       },
       "location": {

--- a/src/configurations/sources/bigquery/db-config.json
+++ b/src/configurations/sources/bigquery/db-config.json
@@ -2,6 +2,11 @@
   "name": "bigquery",
   "category": "warehouse",
   "displayName": "BigQuery",
+  "config": {
+    "supportedAccountDefinitions": {
+      "rudderAccountId": ["SOURCE_BIGQUERY"]
+    }
+  },
   "options": {
     "syncBehaviours": ["upsert", "mirror", "full"],
     "isSqlModelSupported": true,

--- a/src/schemas/sources/db-config-schema.json
+++ b/src/schemas/sources/db-config-schema.json
@@ -269,6 +269,7 @@
           "title": "Supported Account Definitions",
           "description": "Account definitionIds for the source.",
           "$comment": "Account definitionIds (each the `name` of an account definition under this source's accounts/ directory) that this source supports. The account's secret and option fields are declared on the referenced account definition itself (its config.secretFields / config.optionFields, validated by the account's secretSchema / optionsSchema).",
+          "minProperties": 1,
           "properties": {
             "rudderAccountId": {
               "type": "array",
@@ -277,7 +278,7 @@
               "items": {
                 "type": "string"
               },
-              "minItems": 0,
+              "minItems": 1,
               "uniqueItems": true
             }
           }

--- a/src/schemas/sources/db-config-schema.json
+++ b/src/schemas/sources/db-config-schema.json
@@ -258,6 +258,31 @@
           "default": false
         }
       }
+    },
+    "config": {
+      "type": "object",
+      "title": "Configuration",
+      "description": "This hosts all the source parameters.",
+      "properties": {
+        "supportedAccountDefinitions": {
+          "type": "object",
+          "title": "Supported Account Definitions",
+          "description": "Account definitionIds for the source.",
+          "$comment": "For non-OAuth account definitions, all fields (secretFields + optionFields) must also be listed in the account definition's defaultConfig; otherwise the workspace config API will silently drop them from its response. Additionally, any internal secret fields must be listed in options.internalSecretKeys.",
+          "properties": {
+            "rudderAccountId": {
+              "type": "array",
+              "title": "Rudder Account Id",
+              "description": "The account definitionId for the source.",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 0,
+              "uniqueItems": true
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/schemas/sources/db-config-schema.json
+++ b/src/schemas/sources/db-config-schema.json
@@ -268,7 +268,7 @@
           "type": "object",
           "title": "Supported Account Definitions",
           "description": "Account definitionIds for the source.",
-          "$comment": "For non-OAuth account definitions, all fields (secretFields + optionFields) must also be listed in the account definition's defaultConfig; otherwise the workspace config API will silently drop them from its response. Additionally, any internal secret fields must be listed in options.internalSecretKeys.",
+          "$comment": "Account definitionIds (each the `name` of an account definition under this source's accounts/ directory) that this source supports. The account's secret and option fields are declared on the referenced account definition itself (its config.secretFields / config.optionFields, validated by the account's secretSchema / optionsSchema).",
           "properties": {
             "rudderAccountId": {
               "type": "array",

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -379,12 +379,42 @@ describe('Source Definition validation tests', () => {
       expected:
         '["options.internalSecretKeys must NOT have duplicate items (items ## 1 and 0 are identical)"]',
     },
+    {
+      description: 'config.supportedAccountDefinitions.rudderAccountId with non-array value',
+      input: {
+        name: 'test_source',
+        displayName: 'Test Source',
+        type: 'cloud',
+        category: 'webhook',
+        config: {
+          supportedAccountDefinitions: {
+            rudderAccountId: 'SOURCE_TEST_OAUTH',
+          },
+        },
+      },
+      expected: '["config.supportedAccountDefinitions.rudderAccountId must be array"]',
+    },
   ];
 
   it.each(malformedSrcDefConfigs)('$description', async (testCase) => {
     await expect(validateSourceDefinitions(testCase.input)).rejects.toThrow(
       new Error(testCase.expected),
     );
+  });
+
+  it('config.supportedAccountDefinitions.rudderAccountId with valid array value is accepted', async () => {
+    const srcDefConfig = {
+      name: 'test_source',
+      displayName: 'Test Source',
+      type: 'cloud',
+      category: 'webhook',
+      config: {
+        supportedAccountDefinitions: {
+          rudderAccountId: ['SOURCE_TEST_OAUTH'],
+        },
+      },
+    };
+    await expect(validateSourceDefinitions(srcDefConfig)).resolves.toEqual(true);
   });
 });
 

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -394,6 +394,36 @@ describe('Source Definition validation tests', () => {
       },
       expected: '["config.supportedAccountDefinitions.rudderAccountId must be array"]',
     },
+    {
+      description: 'config.supportedAccountDefinitions.rudderAccountId with empty array',
+      input: {
+        name: 'test_source',
+        displayName: 'Test Source',
+        type: 'cloud',
+        category: 'webhook',
+        config: {
+          supportedAccountDefinitions: {
+            rudderAccountId: [],
+          },
+        },
+      },
+      expected:
+        '["config.supportedAccountDefinitions.rudderAccountId must NOT have fewer than 1 items"]',
+    },
+    {
+      description: 'config.supportedAccountDefinitions with empty object',
+      input: {
+        name: 'test_source',
+        displayName: 'Test Source',
+        type: 'cloud',
+        category: 'webhook',
+        config: {
+          supportedAccountDefinitions: {},
+        },
+      },
+      expected:
+        '["config.supportedAccountDefinitions must NOT have fewer than 1 properties"]',
+    },
   ];
 
   it.each(malformedSrcDefConfigs)('$description', async (testCase) => {


### PR DESCRIPTION
## Summary

Foundation config for rETL BigQuery **source** account management (M2 — Foundation Deployed). Three interdependent Linear issues, implemented in dependency order on one branch:

- **[DEX-374](https://linear.app/rudderstack/issue/DEX-374)** — Add a typed `config.supportedAccountDefinitions.rudderAccountId: string[]` to the source db-config JSON Schema (`src/schemas/sources/db-config-schema.json`), mirroring the destinations schema block but source-scoped (only `rudderAccountId`; no destination-only fields/requirements). Includes a corrected `$comment` accurate to source semantics (sources have no `defaultConfig`).
- **[APL-399](https://linear.app/rudderstack/issue/APL-399)** — Create the `SOURCE_BIGQUERY` account definition (`src/configurations/sources/bigquery/accounts/SOURCE_BIGQUERY/{db-config.json,schema.json}`): `category: source`, `authenticationType: service_account_key`, `optionFields` `[project, location]`, `secretFields` `[credentials]`; `optionsSchema` + `secretSchema` (no `combinedSchema`). Also adds a top-level **`CONVENTIONS.md`** documenting the AccountDefinition naming convention (`{CATEGORY}_{TYPE}[_{AUTH_QUALIFIER}]`) with examples, linked from `CONTRIBUTING.md`.
- **[APL-398](https://linear.app/rudderstack/issue/APL-398)** — Tag the BigQuery source: `config.supportedAccountDefinitions.rudderAccountId: ["SOURCE_BIGQUERY"]` in `src/configurations/sources/bigquery/db-config.json`.

End-to-end the names line up: the source references `SOURCE_BIGQUERY`, which is the `name` of the new account definition, and the schema permits exactly that shape.

## Implementation notes

- The account `schema.json` was adapted from the rudder-specs reference rather than copied verbatim, to satisfy the repo's stricter `account-schema-schema.json` (trailing-`#` `$schema`, `pattern` required on each secret field, no inner `additionalProperties`).
- `credentials` uses pattern `^[\s\S]+$` (multiline-capable) so a full multi-line GCP service-account-key JSON validates; the common `.{1,500}` precedent would wrongly reject it.

## Test Plan

- [x] `npx jest test/validation.test.ts` (node 20.11.0 per `.nvmrc`) — **3341 passed, 3341 total**, no regressions
- [x] New `bigquery/SOURCE_BIGQUERY - account definition test` auto-discovered and passing (ajv strict vs `account-db-config-schema.json`)
- [x] `bigquery - source definition test` passing against the updated source schema
- [x] `schema.json` validated against `account-schema-schema.json`; positive + negative tests added for the new schema field
- [ ] Reviewer to confirm: runtime wiring of BigQuery source account credentials through the workspace-config API is handled by downstream tickets (APL-403 auto-tag, APL-407 backfill); this PR is config-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a repository-wide Conventions guide and updated CONTRIBUTING to reference it.

* **New Features**
  * Added BigQuery source integration with account configuration and schema.
  * Introduced configurable supported account definitions for sources.

* **Tests**
  * Added validation tests covering the new supported-account-definition rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->